### PR TITLE
Add filler content for Service Enablement Dashboard

### DIFF
--- a/src/Components/ConfirmChangesModal/index.js
+++ b/src/Components/ConfirmChangesModal/index.js
@@ -28,7 +28,7 @@ const ConfirmChangesModal = ({
           type="button"
           onClick={handleCancel}
         >
-          Confirm Cancel
+          Cancel
         </Button>,
       ]}
     >
@@ -38,7 +38,7 @@ const ConfirmChangesModal = ({
           settings will also be applied to <b>all future systems</b> that are
           connect through Red Hat Connect (rhc).
         </Text>
-        <Text component="p">
+        <Text component="p" className="pf-u-mb-sm">
           Upon confirmation, an Ansible Playbook will be pushed to 1032 systems
           to apply changes.
         </Text>

--- a/src/Routes/Dashboard/SampleTabRoute.js
+++ b/src/Routes/Dashboard/SampleTabRoute.js
@@ -1,5 +1,8 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 import {
+  Badge,
+  Button,
+  Popover,
   Stack,
   StackItem,
   Switch,
@@ -7,26 +10,66 @@ import {
   TextContent,
   Title,
 } from '@patternfly/react-core';
-
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import propTypes from 'prop-types';
 import '@patternfly/react-styles/css/components/Table/table.css';
 
-const SampleTabRoute = () => {
+const SampleTabRoute = ({ setMadeChanges }) => {
+  const defaults = {
+    connectToInsights: true,
+    useOpenSCAP: false,
+    useAnalysis: false,
+    enableCloudConnector: false,
+  };
+  const [connectToInsights, setConnectToInsights] = useState(
+    defaults.connectToInsights
+  );
+  const [useOpenSCAP, setUseOpenSCAP] = useState(defaults.useOpenSCAP);
+  const [useAnalysis, setUseAnalysis] = useState(defaults.useAnalysis);
+  const [enableCloudConnector, setEnableCloudConnector] = useState(
+    defaults.enableCloudConnector
+  );
+
+  useEffect(() => {
+    setMadeChanges(
+      connectToInsights != defaults.connectToInsights ||
+        useOpenSCAP != defaults.useOpenSCAP ||
+        useAnalysis != defaults.useAnalysis ||
+        enableCloudConnector != defaults.enableCloudConnector
+    );
+  }, [connectToInsights, useOpenSCAP, useAnalysis, enableCloudConnector]);
+
+  const getPopover = () => {
+    return (
+      <Popover
+        aria-label="connected-dashboard-description"
+        headerContent={<div>Desc header</div>}
+        bodyContent={<p>Popover description</p>}
+        position="bottom"
+      >
+        <Button variant="plain" className="pf-u-p-xs">
+          <OutlinedQuestionCircleIcon color="grey" />
+        </Button>
+      </Popover>
+    );
+  };
+
   return (
     <Stack hasGutter className="dashboard__sample-route pf-u-p-md">
       <StackItem>
         <Title headingLevel="h2" size="2xl">
-          Red hat Insights
+          Red Hat Insights
         </Title>
-        <TextContent>
+        <TextContent className="pf-u-mt-md">
           <Text component="p">
-            Esse culpa anim do incididunt non cillum nisi esse officia. Culpa
-            elit amet dolore aliqua veniam adipisicing qui anim ea magna. Est
-            anim ex proident tempor nostrud. Veniam aliqua sunt est Lorem
-            proident voluptate. Laboris labore mollit irure officia. Dolore sit
-            velit cillum ut irure esse velit exercitation esse consectetur.
-            Aliquip reprehenderit duis deserunt fugiat proident ex in eiusmod
-            pariatur ipsum sint. Lorem ipsum reprehenderit veniam in esse velit
-            qui ad. Reprehenderit laborum laboris aute ipsum.
+            Red Hat Insights is a proactive operational efficiency and security
+            risk management solution in Red Hat Enterprise Linux (RHEL)
+            subscriptions for versions 6.4 and higher, as well as public cloud
+            versions of RHEL. It helps identify, prioritize, and resolve risks
+            to security, compliance, performance, availability, and stability
+            before they become urgent issues. Insights also enables users to
+            monitor for adherence to internal policies and understand
+            configuration changes over time.
           </Text>
         </TextContent>
       </StackItem>
@@ -37,8 +80,10 @@ const SampleTabRoute = () => {
         <Stack hasGutter className="pf-u-mt-lg">
           <StackItem>
             <Switch
-              id="top-foo"
-              aria-label="foo"
+              id="connect-to-insights"
+              aria-label="Connect to Red Hat Insights"
+              isChecked={connectToInsights}
+              onChange={() => setConnectToInsights(!connectToInsights)}
               label={
                 <Fragment>
                   <Title headingLevel="h4" size="md">
@@ -46,43 +91,93 @@ const SampleTabRoute = () => {
                   </Title>
                   <TextContent>
                     <Text component="small">
-                      Id culpa nostrud magna cupidatat commodo dolor tempor enim
-                      nisi irure duis sunt. Amet commodo dolore adipisicing
-                      velit aliquip est. Id laboris aute pariatur nulla. Fugiat
-                      qui exercitation ad sit. Dolore sit eiusmod et cupidatat
-                      qui cillum nulla pariatur consequat nulla irure deserunt
-                      incididunt esse.
+                      Required to use Insights applications. Enables Advisor,
+                      Drift, Patch, Vulnerability and Policies applications.
                     </Text>
                   </TextContent>
                 </Fragment>
               }
             />
             <div className="pf-u-pl-3xl">
-              {[1, 2, 3].map((val) => (
-                <Switch
-                  className="pf-u-mt-md"
-                  key={val}
-                  id={`${val}-nested-switch`}
-                  aria-label={`${val}-nested-switch`}
-                  label={
-                    <Fragment>
-                      <Title headingLevel="h4" size="md">
-                        Nested switch {val}
-                      </Title>
-                      <TextContent>
-                        <Text component="small">
-                          Id culpa nostrud magna cupidatat commodo dolor tempor
-                          enim nisi irure duis sunt. Amet commodo dolore
-                          adipisicing velit aliquip est. Id laboris aute
-                          pariatur nulla. Fugiat qui exercitation ad sit. Dolore
-                          sit eiusmod et cupidatat qui cillum nulla pariatur
-                          consequat nulla irure deserunt incididunt esse.
-                        </Text>
-                      </TextContent>
-                    </Fragment>
-                  }
-                />
-              ))}
+              <Stack>
+                <StackItem>
+                  <Switch
+                    className="pf-u-mt-md"
+                    key="use-openscap"
+                    id="use-openscap"
+                    aria-label="Use OpenSCAP for Compliance policies"
+                    isChecked={useOpenSCAP}
+                    onChange={() => setUseOpenSCAP(!useOpenSCAP)}
+                    label={
+                      <Fragment>
+                        <Title headingLevel="h4" size="md">
+                          Use OpenSCAP for Compliance policies
+                          {getPopover()}
+                        </Title>
+                        <TextContent>
+                          <Text component="small">
+                            Required to use Compliance application
+                          </Text>
+                        </TextContent>
+                      </Fragment>
+                    }
+                  />
+                </StackItem>
+                <StackItem>
+                  <Switch
+                    className="pf-u-mt-md"
+                    key="use-resource-optimization"
+                    id="use-resource-optimization"
+                    aria-label="Use Resource Optimization analysis"
+                    isChecked={useAnalysis}
+                    onChange={() => setUseAnalysis(!useAnalysis)}
+                    label={
+                      <Fragment>
+                        <Title headingLevel="h4" size="md">
+                          Use Resource Optimization analysis
+                          <Badge className="pf-u-ml-sm pf-u-mr-xs" isRead>
+                            Beta
+                          </Badge>
+                          {getPopover()}
+                        </Title>
+                        <TextContent>
+                          <Text component="small">
+                            Required to use Resource Optimization application
+                          </Text>
+                        </TextContent>
+                      </Fragment>
+                    }
+                  />
+                </StackItem>
+                <StackItem>
+                  <Switch
+                    className="pf-u-mt-md"
+                    key="enable-cloud-connector"
+                    id="enable-cloud-connector"
+                    aria-label="Enable Cloud Connector"
+                    isChecked={enableCloudConnector}
+                    onChange={() =>
+                      setEnableCloudConnector(!enableCloudConnector)
+                    }
+                    label={
+                      <Fragment>
+                        <Title headingLevel="h4" size="md">
+                          Enable Cloud Connector to fix issues directly from
+                          Insights
+                          {getPopover()}
+                        </Title>
+                        <TextContent>
+                          <Text component="small">
+                            Cloud Connector allows you to push Remediation
+                            Ansible Playbooks directly from Insights to your
+                            systems.
+                          </Text>
+                        </TextContent>
+                      </Fragment>
+                    }
+                  />
+                </StackItem>
+              </Stack>
             </div>
           </StackItem>
           <StackItem>
@@ -116,6 +211,10 @@ const SampleTabRoute = () => {
       </StackItem>
     </Stack>
   );
+};
+
+SampleTabRoute.propTypes = {
+  setMadeChanges: propTypes.func.isRequired,
 };
 
 export default SampleTabRoute;

--- a/src/Routes/Dashboard/SampleTabRoute.js
+++ b/src/Routes/Dashboard/SampleTabRoute.js
@@ -47,7 +47,11 @@ const SampleTabRoute = ({ setMadeChanges }) => {
         bodyContent={<p>Popover description</p>}
         position="bottom"
       >
-        <Button variant="plain" className="pf-u-p-xs">
+        <Button
+          ouiaId="title-popover-button"
+          variant="plain"
+          className="pf-u-p-xs"
+        >
           <OutlinedQuestionCircleIcon color="grey" />
         </Button>
       </Popover>
@@ -81,6 +85,7 @@ const SampleTabRoute = ({ setMadeChanges }) => {
           <StackItem>
             <Switch
               id="connect-to-insights"
+              ouiaId="connect-to-insights"
               aria-label="Connect to Red Hat Insights"
               isChecked={connectToInsights}
               onChange={() => setConnectToInsights(!connectToInsights)}
@@ -105,6 +110,7 @@ const SampleTabRoute = ({ setMadeChanges }) => {
                     className="pf-u-mt-md"
                     key="use-openscap"
                     id="use-openscap"
+                    ouiaId="use-openscap"
                     aria-label="Use OpenSCAP for Compliance policies"
                     isChecked={useOpenSCAP}
                     onChange={() => setUseOpenSCAP(!useOpenSCAP)}
@@ -128,6 +134,7 @@ const SampleTabRoute = ({ setMadeChanges }) => {
                     className="pf-u-mt-md"
                     key="use-resource-optimization"
                     id="use-resource-optimization"
+                    ouiaId="use-resource-optimization"
                     aria-label="Use Resource Optimization analysis"
                     isChecked={useAnalysis}
                     onChange={() => setUseAnalysis(!useAnalysis)}
@@ -154,6 +161,7 @@ const SampleTabRoute = ({ setMadeChanges }) => {
                     className="pf-u-mt-md"
                     key="enable-cloud-connector"
                     id="enable-cloud-connector"
+                    ouiaId="enable-cloud-connector"
                     aria-label="Enable Cloud Connector"
                     isChecked={enableCloudConnector}
                     onChange={() =>

--- a/src/Routes/Dashboard/SampleTabRoute.js
+++ b/src/Routes/Dashboard/SampleTabRoute.js
@@ -55,7 +55,7 @@ const SampleTabRoute = ({ setMadeChanges }) => {
   };
 
   return (
-    <Stack hasGutter className="dashboard__sample-route pf-u-p-md">
+    <Stack hasGutter className="pf-u-p-md">
       <StackItem>
         <Title headingLevel="h2" size="2xl">
           Red Hat Insights
@@ -179,33 +179,6 @@ const SampleTabRoute = ({ setMadeChanges }) => {
                 </StackItem>
               </Stack>
             </div>
-          </StackItem>
-          <StackItem>
-            <Title headingLevel="h3" size="xl">
-              Exclusions
-            </Title>
-            <table className="pf-c-table pf-m-grid-md">
-              <thead>
-                <tr>
-                  <th>Condition</th>
-                  <th>Settings</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>tag=&quot;prod&quot;</td>
-                  <td>Red Hat Insights - Off</td>
-                </tr>
-                <tr>
-                  <td>tag=&quot;dev&quot;</td>
-                  <td>
-                    Red Hat Insights - On
-                    <br />
-                    YARA - On
-                  </td>
-                </tr>
-              </tbody>
-            </table>
           </StackItem>
         </Stack>
       </StackItem>

--- a/src/Routes/Dashboard/dashboard.scss
+++ b/src/Routes/Dashboard/dashboard.scss
@@ -20,9 +20,6 @@
   &tabs-nav{
     flex-shrink: 0;
   }
-  &sample-route {
-    border-left: 1px solid var(--pf-global--BorderColor--100);
-  }
   &in-progress-text {
     color: var(--pf-global--palette--blue-500);
     > svg {

--- a/src/Routes/Dashboard/index.js
+++ b/src/Routes/Dashboard/index.js
@@ -1,6 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Route, Switch } from 'react-router-dom';
-
 import {
   Button,
   Divider,
@@ -24,43 +22,11 @@ import {
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 
 import './dashboard.scss';
-import NavTabs from '../../Components/NavTabs';
 import SampleTabRoute from './SampleTabRoute';
 import ConfirmChangesModal from '../../Components/ConfirmChangesModal';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import ConnectLog from '../../Components/ConnectLog';
-
-const tabItems = [
-  {
-    eventKey: 0,
-    pathname: '/red-hat-insights',
-    title: (
-      <Level hasGutter className="dashboard__navtab-title">
-        <LevelItem>Red Hat Insights</LevelItem>
-        <LevelItem>
-          <Text component="b">
-            <span className="dashboard__success-status">ON</span>
-          </Text>
-        </LevelItem>
-      </Level>
-    ),
-  },
-  {
-    eventKey: 1,
-    pathname: '/red-hat-subscription-manager',
-    title: (
-      <Level hasGutter className="dashboard__navtab-title">
-        <LevelItem>Red Hat Subscription manager</LevelItem>
-        <LevelItem>
-          <Text component="b">
-            <span className="dashboard__success-status">ON</span>
-          </Text>
-        </LevelItem>
-      </Level>
-    ),
-  },
-];
 
 const SamplePage = () => {
   const [confirmChangesOpen, setConfirmChangesOpen] = useState(false);
@@ -147,23 +113,7 @@ const SamplePage = () => {
             </StackItem>
           </Stack>
           <Divider />
-          <div className="dashboard__tabs-content">
-            <NavTabs
-              tabItems={tabItems}
-              TabsProps={{
-                isVertical: true,
-                className: 'dashboard__tabs-nav pf-u-mr-lg',
-              }}
-            />
-            <Switch>
-              <Route path={tabItems[1].pathname}>
-                <div>No component yet</div>
-              </Route>
-              <Route path={['/', tabItems[0].pathname]}>
-                <SampleTabRoute setMadeChanges={setMadeChanges} />
-              </Route>
-            </Switch>
-          </div>
+          <SampleTabRoute setMadeChanges={setMadeChanges} />
         </div>
       </Main>
       <ConfirmChangesModal

--- a/src/Routes/Dashboard/index.js
+++ b/src/Routes/Dashboard/index.js
@@ -66,6 +66,7 @@ const SamplePage = () => {
   const [confirmChangesOpen, setConfirmChangesOpen] = useState(false);
   const [logsOpen, setLogsOpen] = useState(false);
   const [wasConfirmed, setWasConfirmed] = useState(false);
+  const [madeChanges, setMadeChanges] = useState(false);
   const dispatch = useDispatch();
   useEffect(() => {
     insights?.chrome?.appAction?.('sample-page');
@@ -129,12 +130,13 @@ const SamplePage = () => {
                       </Text>
                     )}
                   </Flex>
-                  <a href="#">
-                    Connect RHEL 6 and 7 systems (link does not work)
-                  </a>
+                  <a href="#">Connect RHEL 6 and 7 systems</a>
                 </LevelItem>
                 <LevelItem>
-                  <Button onClick={() => setConfirmChangesOpen(true)}>
+                  <Button
+                    isDisabled={!madeChanges}
+                    onClick={() => setConfirmChangesOpen(true)}
+                  >
                     Save changes
                   </Button>
                   <Button onClick={() => setLogsOpen(true)} variant="link">
@@ -158,7 +160,7 @@ const SamplePage = () => {
                 <div>No component yet</div>
               </Route>
               <Route path={['/', tabItems[0].pathname]}>
-                <SampleTabRoute />
+                <SampleTabRoute setMadeChanges={setMadeChanges} />
               </Route>
             </Switch>
           </div>

--- a/src/Routes/Dashboard/index.js
+++ b/src/Routes/Dashboard/index.js
@@ -100,6 +100,7 @@ const SamplePage = () => {
                 </LevelItem>
                 <LevelItem>
                   <Button
+                    ouiaId="primary-save-button"
                     isDisabled={!madeChanges}
                     onClick={() => setConfirmChangesOpen(true)}
                   >


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-12367

**acceptance criteria:**
- Each of those switches should be able to toggle
- ~~If you toggle the top one "Connect to Red Hat Insights" it should toggle all of the switches on/off~~
- "Save changes" should only turn on when a change is made
- If you click "Save changes" you should get an alert saying your changes were saved
- We will not click "View log"
- Save button needs to display a fake confirmation message

**default state:**
- Connect to Red Hat Insights (on)
- All the other 3 are off, but the demo person will toggle them on

**what may be missing:**
- No content in "?" button popovers
- "Connect RHEL 6 and 7 systems" link URL

![001](https://user-images.githubusercontent.com/50696716/108234596-3e7d1900-7145-11eb-92d5-f31de1f3cdaa.png)

![002](https://user-images.githubusercontent.com/50696716/108234607-40df7300-7145-11eb-81b0-0ffd9399ccd7.png)

![003](https://user-images.githubusercontent.com/50696716/108234618-4341cd00-7145-11eb-8b23-a1ff3ce37395.png)

