### PR TITLE
Activation keys components

### DIFF
--- a/src/Components/ActivationKeys/activation-keys-table.js
+++ b/src/Components/ActivationKeys/activation-keys-table.js
@@ -1,0 +1,163 @@
+import React, { Fragment, useEffect, useState } from 'react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  sortable,
+} from '@patternfly/react-table';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Grid,
+  GridItem,
+  Text,
+  TextContent,
+  Title,
+} from '@patternfly/react-core';
+import { CopyIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import SkeletonTable from '@redhat-cloud-services/frontend-components/SkeletonTable';
+import CopyCommand from './copy-command';
+
+const mockGetData = () =>
+  new Promise((res) =>
+    setTimeout(
+      () =>
+        res([
+          {
+            name: 'sample-name-1',
+            role: 'Red Hat Linux Server',
+            level: 'Premium',
+            usage: 'Production',
+          },
+          {
+            name: 'sample-name-2',
+            role: 'Red Hat Linux Workstation',
+            level: 'Standard',
+            usage: 'Development/Test',
+          },
+          {
+            name: 'sample-name-3',
+            role: 'Red Hat Linux Compute Node',
+            level: 'Self-Suport',
+            usage: 'Disaster Recovery',
+          },
+        ]),
+      250
+    )
+  );
+
+const columns = [
+  { title: 'Name', transforms: [sortable] },
+  { title: 'Role', transforms: [sortable] },
+  { title: 'Service level', transforms: [sortable] },
+  { title: 'Usage', transforms: [sortable] },
+  { title: '' },
+];
+
+function ActivationKeysTable() {
+  const [data, setData] = useState(undefined);
+  const [orgId, setOrgId] = useState(undefined);
+  const [sortBy, setSortBy] = useState({ index: 0, direction: 'asc' });
+
+  const handleTableButtonClick = (name, data) => {
+    const row = data.find((row) => row.name === name);
+    const elem = document.createElement('input');
+    elem.id = `temp-${name}`;
+    elem.type = 'text';
+    elem.value = JSON.stringify(row);
+    document.body.appendChild(elem);
+    document.getElementById(`temp-${name}`).select();
+    document.execCommand('copy');
+    document.body.removeChild(elem);
+  };
+
+  useEffect(() => {
+    window.insights.chrome.auth
+      .getUser()
+      .then((user) => setOrgId(user?.identity?.internal?.org_id));
+    mockGetData().then((data) =>
+      setData(
+        data.map(({ name, role, level, usage }) => [
+          name,
+          role,
+          level,
+          usage,
+          <Fragment key="copy">
+            <Button
+              onClick={() => handleTableButtonClick(name, data)}
+              variant="plain"
+              aria-label="copy"
+            >
+              <CopyIcon />
+            </Button>
+          </Fragment>,
+        ])
+      )
+    );
+  }, []);
+
+  const onSort = (_event, index, direction) => {
+    setSortBy({ index, direction });
+    setData((prev) => {
+      const rows = prev.sort((a, b) => a[index].localeCompare(b[index]));
+      return direction === 'asc' ? [...rows] : [...rows.reverse()];
+    });
+  };
+
+  return (
+    <div className="pf-u-p-lg">
+      {!data ? (
+        <SkeletonTable rows={5} columns={5} />
+      ) : (
+        <Fragment>
+          <Flex
+            alignItems={{ default: 'alignItemsBaseline' }}
+            className="pf-u-mb-lg"
+          >
+            <FlexItem className="pf-u-mr-md">
+              <Title headingLevel="h2" size="2xl">
+                Activation keys
+              </Title>
+            </FlexItem>
+            <FlexItem>
+              <a href="#">
+                Manage activation keys <ExternalLinkAltIcon />
+              </a>
+            </FlexItem>
+          </Flex>
+          <TextContent>
+            <Text>
+              Use activation keys to associate your system with a subscription
+              when registering with Red Hat connect (rhc).
+            </Text>
+          </TextContent>
+          <Grid>
+            <GridItem sm={12} md={6} lg={4}>
+              <CopyCommand />
+            </GridItem>
+          </Grid>
+          <Title className="pf-u-mt-lg" size="xl" headingLevel="h3">
+            Activation keys
+          </Title>
+          <TextContent className="pf-u-mb-lg">
+            <Text>Organization ID: {orgId}</Text>
+          </TextContent>
+          <Table
+            aria-label="activation keys table"
+            sortBy={sortBy}
+            onSort={onSort}
+            variant="compact"
+            cells={columns}
+            rows={data}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </Fragment>
+      )}
+    </div>
+  );
+}
+
+export default ActivationKeysTable;

--- a/src/Components/ActivationKeys/copy-command.js
+++ b/src/Components/ActivationKeys/copy-command.js
@@ -1,0 +1,16 @@
+import { ClipboardCopy, Form, FormGroup } from '@patternfly/react-core';
+import React from 'react';
+
+function CopyCommand() {
+  return (
+    <Form className="pf-u-mt-md" onSubmit={(event) => event.preventDefault()}>
+      <FormGroup label="RHC command for registration">
+        <ClipboardCopy>
+          rhc connect -[activationkey-namehere] -[organization ID]
+        </ClipboardCopy>
+      </FormGroup>
+    </Form>
+  );
+}
+
+export default CopyCommand;

--- a/src/Components/ActivationKeys/copy-command.js
+++ b/src/Components/ActivationKeys/copy-command.js
@@ -1,16 +1,14 @@
 import { ClipboardCopy, Form, FormGroup } from '@patternfly/react-core';
 import React from 'react';
 
-function CopyCommand() {
-  return (
-    <Form className="pf-u-mt-md" onSubmit={(event) => event.preventDefault()}>
-      <FormGroup label="RHC command for registration">
-        <ClipboardCopy>
-          rhc connect -[activationkey-namehere] -[organization ID]
-        </ClipboardCopy>
-      </FormGroup>
-    </Form>
-  );
-}
+const CopyCommand = () => (
+  <Form className="pf-u-mt-md" onSubmit={(event) => event.preventDefault()}>
+    <FormGroup label="RHC command for registration">
+      <ClipboardCopy>
+        rhc connect -[activationkey-namehere] -[organization ID]
+      </ClipboardCopy>
+    </FormGroup>
+  </Form>
+);
 
 export default CopyCommand;

--- a/src/Components/ActivationKeys/index.js
+++ b/src/Components/ActivationKeys/index.js
@@ -1,0 +1,21 @@
+import { Title } from '@patternfly/react-core';
+import React from 'react';
+import ActivationKeysTable from './activation-keys-table';
+import NoAccessView from './no-access';
+
+function ActivationKeys() {
+  return (
+    <div>
+      <Title size="2xl" headingLevel="h1">
+        Following content will be in a separate tab. Data is mocked, we
+        don&#39;t know the API endpoint yet.
+      </Title>
+      {/** This will be visible to org admins */}
+      <ActivationKeysTable />
+      {/* This will be visible only to non org admins */}
+      <NoAccessView />
+    </div>
+  );
+}
+
+export default ActivationKeys;

--- a/src/Components/ActivationKeys/index.js
+++ b/src/Components/ActivationKeys/index.js
@@ -1,20 +1,32 @@
-import { Title } from '@patternfly/react-core';
 import React from 'react';
-import ActivationKeysTable from './activation-keys-table';
-import NoAccessView from './no-access';
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+} from '@patternfly/react-core';
+import { LockIcon } from '@patternfly/react-icons';
 
 function ActivationKeys() {
   return (
-    <div>
-      <Title size="2xl" headingLevel="h1">
-        Following content will be in a separate tab. Data is mocked, we
-        don&#39;t know the API endpoint yet.
-      </Title>
-      {/** This will be visible to org admins */}
-      <ActivationKeysTable />
-      {/* This will be visible only to non org admins */}
-      <NoAccessView />
-    </div>
+    <Bullseye>
+      <EmptyState>
+        <EmptyStateIcon icon={LockIcon} />
+        <Title headingLevel="h4" size="lg">
+          This feature is not currently supported
+        </Title>
+        <Button
+          component="a"
+          variant="link"
+          href="https://access.redhat.com/articles/simple-content-access"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Customer portal
+        </Button>
+      </EmptyState>
+    </Bullseye>
   );
 }
 

--- a/src/Components/ActivationKeys/index.js
+++ b/src/Components/ActivationKeys/index.js
@@ -8,26 +8,24 @@ import {
 } from '@patternfly/react-core';
 import { LockIcon } from '@patternfly/react-icons';
 
-function ActivationKeys() {
-  return (
-    <Bullseye>
-      <EmptyState>
-        <EmptyStateIcon icon={LockIcon} />
-        <Title headingLevel="h4" size="lg">
-          This feature is not currently supported
-        </Title>
-        <Button
-          component="a"
-          variant="link"
-          href="https://access.redhat.com/articles/simple-content-access"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          Customer portal
-        </Button>
-      </EmptyState>
-    </Bullseye>
-  );
-}
+const ActivationKeys = () => (
+  <Bullseye>
+    <EmptyState>
+      <EmptyStateIcon icon={LockIcon} />
+      <Title headingLevel="h4" size="lg">
+        This feature is not currently supported
+      </Title>
+      <Button
+        component="a"
+        variant="link"
+        href="https://access.redhat.com/articles/simple-content-access"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        Customer portal
+      </Button>
+    </EmptyState>
+  </Bullseye>
+);
 
 export default ActivationKeys;

--- a/src/Components/ActivationKeys/no-access.js
+++ b/src/Components/ActivationKeys/no-access.js
@@ -1,0 +1,30 @@
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Title,
+} from '@patternfly/react-core';
+import { LockIcon } from '@patternfly/react-icons';
+import React from 'react';
+import CopyCommand from './copy-command';
+
+function NoAccessView() {
+  return (
+    <Bullseye>
+      <EmptyState>
+        <EmptyStateIcon icon={LockIcon} />
+        <Title headingLevel="h4" size="lg">
+          Activation keys can only be accessed by organization administrators.
+        </Title>
+        <EmptyStateBody>
+          If you already know your organization ID and activation key, you can
+          register systems with RHC.
+        </EmptyStateBody>
+        <CopyCommand />
+      </EmptyState>
+    </Bullseye>
+  );
+}
+
+export default NoAccessView;

--- a/src/Components/ActivationKeys/no-access.js
+++ b/src/Components/ActivationKeys/no-access.js
@@ -9,22 +9,20 @@ import { LockIcon } from '@patternfly/react-icons';
 import React from 'react';
 import CopyCommand from './copy-command';
 
-function NoAccessView() {
-  return (
-    <Bullseye>
-      <EmptyState>
-        <EmptyStateIcon icon={LockIcon} />
-        <Title headingLevel="h4" size="lg">
-          Activation keys can only be accessed by organization administrators.
-        </Title>
-        <EmptyStateBody>
-          If you already know your organization ID and activation key, you can
-          register systems with RHC.
-        </EmptyStateBody>
-        <CopyCommand />
-      </EmptyState>
-    </Bullseye>
-  );
-}
+const NoAccessView = () => (
+  <Bullseye>
+    <EmptyState>
+      <EmptyStateIcon icon={LockIcon} />
+      <Title headingLevel="h4" size="lg">
+        Activation keys can only be accessed by organization administrators.
+      </Title>
+      <EmptyStateBody>
+        If you already know your organization ID and activation key, you can
+        register systems with RHC.
+      </EmptyStateBody>
+      <CopyCommand />
+    </EmptyState>
+  </Bullseye>
+);
 
 export default NoAccessView;

--- a/src/Components/Services/Services.js
+++ b/src/Components/Services/Services.js
@@ -1,6 +1,8 @@
 import React, { Fragment, useState, useEffect } from 'react';
 import {
   Button,
+  Level,
+  LevelItem,
   Popover,
   Stack,
   StackItem,
@@ -9,11 +11,30 @@ import {
   TextContent,
   Title,
 } from '@patternfly/react-core';
+import { shallowEqual, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import propTypes from 'prop-types';
+
+import pckg from '../../../package.json';
 import '@patternfly/react-styles/css/components/Table/table.css';
 
-const SampleTabRoute = ({ setMadeChanges, defaults, onChange }) => {
+const { routes: paths } = pckg;
+
+const Services = ({
+  setMadeChanges,
+  defaults,
+  onChange,
+  madeChanges,
+  setConfirmChangesOpen,
+}) => {
+  const { push } = useHistory();
+  const { systemsLoaded } = useSelector(
+    ({ connectedSystemsReducer }) => ({
+      systemsLoaded: connectedSystemsReducer?.loaded,
+    }),
+    shallowEqual
+  );
   const [connectToInsights, setConnectToInsights] = useState(
     defaults.hasInsights ||
       defaults.useOpenSCAP ||
@@ -55,9 +76,25 @@ const SampleTabRoute = ({ setMadeChanges, defaults, onChange }) => {
   return (
     <Stack hasGutter className="pf-u-p-md">
       <StackItem>
-        <Title headingLevel="h2" size="2xl">
-          Red Hat Insights
-        </Title>
+        <Level>
+          <LevelItem>
+            <Title headingLevel="h2" size="2xl">
+              Red Hat Insights
+            </Title>
+          </LevelItem>
+          <LevelItem>
+            <Button
+              ouiaId="primary-save-button"
+              isDisabled={!systemsLoaded || !madeChanges}
+              onClick={() => setConfirmChangesOpen(true)}
+            >
+              Save changes
+            </Button>
+            <Button onClick={() => push(paths.logModal)} variant="link">
+              View log
+            </Button>
+          </LevelItem>
+        </Level>
         <TextContent className="pf-u-mt-md">
           <Text component="p">
             Red Hat Insights is a proactive operational efficiency and security
@@ -180,7 +217,7 @@ const SampleTabRoute = ({ setMadeChanges, defaults, onChange }) => {
   );
 };
 
-SampleTabRoute.propTypes = {
+Services.propTypes = {
   setMadeChanges: propTypes.func.isRequired,
   defaults: propTypes.shape({
     useOpenSCAP: propTypes.bool,
@@ -188,9 +225,11 @@ SampleTabRoute.propTypes = {
     enableCloudConnector: propTypes.bool,
   }),
   onChange: propTypes.func.isRequired,
+  madeChanges: propTypes.bool,
+  setConfirmChangesOpen: propTypes.func.isRequired,
 };
 
-SampleTabRoute.defaultProps = {
+Services.defaultProps = {
   defaults: {
     useOpenSCAP: false,
     hasInsights: false,
@@ -198,4 +237,4 @@ SampleTabRoute.defaultProps = {
   },
 };
 
-export default SampleTabRoute;
+export default Services;

--- a/src/Routes/Dashboard/index.js
+++ b/src/Routes/Dashboard/index.js
@@ -49,6 +49,7 @@ import {
 import { Link, Route } from 'react-router-dom';
 import pckg from '../../../package.json';
 import NoSystemsAlert from '../../Components/NoSytemsAlert';
+import ActivationKeys from '../../Components/ActivationKeys';
 
 const { routes: paths } = pckg;
 
@@ -225,6 +226,9 @@ const SamplePage = () => {
               <Spinner size="xl" />
             </Bullseye>
           )}
+          <div className="pf-u-mt-xl">
+            <ActivationKeys />
+          </div>
         </div>
       </Main>
       <ConfirmChangesModal

--- a/src/Routes/Dashboard/index.js
+++ b/src/Routes/Dashboard/index.js
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import {
   Button,
-  Divider,
   Flex,
   Level,
   LevelItem,
@@ -20,12 +19,14 @@ import {
   Spinner,
   Bullseye,
   Skeleton,
+  Tabs,
+  Tab,
+  TabTitleText,
 } from '@patternfly/react-core';
 import {
   OutlinedQuestionCircleIcon,
   InProgressIcon,
 } from '@patternfly/react-icons';
-import { useHistory } from 'react-router-dom';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import {
@@ -34,7 +35,6 @@ import {
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 
 import './dashboard.scss';
-import SampleTabRoute from './SampleTabRoute';
 import ConfirmChangesModal from '../../Components/ConfirmChangesModal';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
@@ -50,6 +50,7 @@ import { Link, Route } from 'react-router-dom';
 import pckg from '../../../package.json';
 import NoSystemsAlert from '../../Components/NoSytemsAlert';
 import ActivationKeys from '../../Components/ActivationKeys';
+import Services from '../../Components/Services/Services';
 
 const { routes: paths } = pckg;
 
@@ -64,7 +65,7 @@ const ConnectLog = lazy(() =>
 );
 
 const SamplePage = () => {
-  const { push } = useHistory();
+  const [activeTabKey, setActiveTabKey] = useState('services');
   const [confirmChangesOpen, setConfirmChangesOpen] = useState(false);
   const [isGuideOpen, setIsGuideOpen] = useState(true);
   const [madeChanges, setMadeChanges] = useState(false);
@@ -192,43 +193,48 @@ const SamplePage = () => {
                     Connect RHEL 6 and 7 systems
                   </Link>
                 </LevelItem>
-                <LevelItem>
-                  <Button
-                    ouiaId="primary-save-button"
-                    isDisabled={!systemsLoaded || !madeChanges}
-                    onClick={() => setConfirmChangesOpen(true)}
-                  >
-                    Save changes
-                  </Button>
-                  <Button onClick={() => push(paths.logModal)} variant="link">
-                    View log
-                  </Button>
-                </LevelItem>
               </Level>
             </StackItem>
           </Stack>
-          <Divider />
-          {activeStateLoaded ||
-          (useOpenSCAP !== undefined && enableCloudConnector !== undefined) ? (
-            <SampleTabRoute
-              setMadeChanges={setMadeChanges}
-              defaults={{
-                useOpenSCAP,
-                enableCloudConnector,
-                hasInsights,
-              }}
-              onChange={(data) => {
-                dataRef.current = data;
-              }}
-            />
-          ) : (
-            <Bullseye>
-              <Spinner size="xl" />
-            </Bullseye>
-          )}
-          <div className="pf-u-mt-xl">
-            <ActivationKeys />
-          </div>
+          <Tabs
+            activeKey={activeTabKey}
+            onSelect={(_event, activeTabKey) => setActiveTabKey(activeTabKey)}
+          >
+            <Tab
+              title={<TabTitleText>Services</TabTitleText>}
+              eventKey="services"
+            >
+              {activeStateLoaded ||
+              (useOpenSCAP !== undefined &&
+                enableCloudConnector !== undefined) ? (
+                <Services
+                  madeChanges={madeChanges}
+                  setConfirmChangesOpen={setConfirmChangesOpen}
+                  setMadeChanges={setMadeChanges}
+                  defaults={{
+                    useOpenSCAP,
+                    enableCloudConnector,
+                    hasInsights,
+                  }}
+                  onChange={(data) => {
+                    dataRef.current = data;
+                  }}
+                />
+              ) : (
+                <Bullseye>
+                  <Spinner className="pf-u-p-lg" size="xl" />
+                </Bullseye>
+              )}
+            </Tab>
+            <Tab
+              eventKey="activation-keys"
+              title={<TabTitleText>Activation keys</TabTitleText>}
+            >
+              <div className="pf-u-m-md">
+                <ActivationKeys />
+              </div>
+            </Tab>
+          </Tabs>
         </div>
       </Main>
       <ConfirmChangesModal


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-13717

### Changes
- added activation keys placeholder components
- split content into tabs as depicted in mocks
- added empty state for activation keys with a lonk to customer portal

~~I've added the required components. Their placement is TBD. I will leave that to @karelhala. Let me know if you want me to hide them from the main dashboard for now.~~

![screenshot-ci foo redhat com_1337-2021 05 05-10_30_58](https://user-images.githubusercontent.com/22619452/117115283-353b3a00-ad8d-11eb-9619-d5b3b1a232ab.png)


![screenshot-ci foo redhat com_1337-2021 05 05-10_31_06](https://user-images.githubusercontent.com/22619452/117115278-32d8e000-ad8d-11eb-9061-7ff600464181.png)


