### PR TITLE
enable insights management and set useOpenSCAP to secondary row

### DIFF
--- a/src/Components/Services/Services.js
+++ b/src/Components/Services/Services.js
@@ -55,6 +55,7 @@ const Services = ({
       isDisabled: false,
     },
     useOpenSCAP: { value: defaults.useOpenSCAP, isDisabled: false },
+    hasInsights: { value: defaults.hasInsights, isDisabled: false },
   };
   const [formState, setFormState] = useState(initState);
   const [madeChanges, setMadeChanges] = useState(false);
@@ -81,11 +82,14 @@ const Services = ({
   useEffect(() => {
     setMadeChanges(
       formState.useOpenSCAP.value !== defaults.useOpenSCAP ||
-        formState.enableCloudConnector.value != defaults.enableCloudConnector
+        formState.enableCloudConnector.value !==
+          defaults.enableCloudConnector ||
+        formState.hasInsights.value !== defaults.hasInsights
     );
     onChange({
       useOpenSCAP: formState.useOpenSCAP.value,
       enableCloudConnector: formState.enableCloudConnector.value,
+      hasInsights: formState.hasInsights.value,
     });
   }, [formState]);
 

--- a/src/Components/Services/permissionsConfig.js
+++ b/src/Components/Services/permissionsConfig.js
@@ -1,8 +1,33 @@
 export const permissions = [
   {
+    id: 'enableCloudConnector',
+    name: 'Allow Insights users to use “Remediations” to send Ansible Playbooks to fix issues on your systems',
+    description:
+      'Users can create Ansible Playbooks using the “Remediate” function in Insights and then execute these playbooks on systems in inventory. Playbooks are sent to systems to fix issues using the Cloud Connector technology.',
+    links: [
+      {
+        name: 'About Cloud Connector',
+        link: 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html-single/red_hat_connector_configuration_guide/index',
+      },
+    ],
+  },
+  {
+    id: 'hasInsights',
+    name: 'Allow remote host configuration to manage the configuration of Red Hat services',
+    description:
+      'Based on changes users make in this settings area, the remote host configuration tool can push Ansible Playbooks to connected systems to update their configutaions. This includes turning these configurations on and off, based on selections.',
+    links: [
+      {
+        name: 'View configuration manager playbooks',
+        link: 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_rhel_resource_optimization_with_insights_for_red_hat_enterprise_linux/index',
+      },
+    ],
+  },
+  {
     id: 'useOpenSCAP',
+    secondary: true,
     name: 'Service: Use OpenSCAP for Compliance policies',
-    additionalInfo: 'Requires Insights',
+    additionalInfo: 'Requires Insights; Configuration management',
     description:
       'This setting installs OpenSCAP for connected systems and ensures that systems are using the most current versions of profiles and policies. OpenSCAP is required for systems to use the compliance service.',
     links: [
@@ -13,18 +38,6 @@ export const permissions = [
       {
         name: 'View configuration playbook',
         link: 'https://github.com/RedHatInsights/config-manager/tree/master/playbooks',
-      },
-    ],
-  },
-  {
-    id: 'enableCloudConnector',
-    name: 'Allow Insights users to use “Remediations” to send Ansible Playbooks to fix issues on your systems',
-    description:
-      'Users can create Ansible Playbooks using the “Remediate” function in Insights and then execute these playbooks on systems in inventory. Playbooks are sent to systems to fix issues using the Cloud Connector technology.',
-    links: [
-      {
-        name: 'About Cloud Connector',
-        link: 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html-single/red_hat_connector_configuration_guide/index',
       },
     ],
   },


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/ESSNTL-3099

1. adds insights management row (the link for the docs is taken from [here](https://docs.google.com/document/d/1xRxOdazla0sQCgsQCh9GsBDhoxycdpLVdRA5S6K6p-w/edit). I hope that this is up to date link)
2. sets useOpenSCAP row as secondary
3. modifies the additional info of useOpenSCAP to 'Requires Insights; Configuration management'

before:
![image](https://user-images.githubusercontent.com/59481011/181733657-aa27ccc4-02e2-41f6-a47f-6af07ba903c2.png)

after:
![image](https://user-images.githubusercontent.com/59481011/181733735-5d2268c8-bb5e-4424-b05c-d9e38f662e48.png)
