### PR TITLE
fix the api request to change settings

### DIFF
--- a/src/Components/Services/Services.js
+++ b/src/Components/Services/Services.js
@@ -55,7 +55,7 @@ const Services = ({
       isDisabled: false,
     },
     useOpenSCAP: { value: defaults.useOpenSCAP, isDisabled: false },
-    hasInsights: { value: defaults.hasInsights, isDisabled: false },
+    apply_state: { value: defaults.apply_state, isDisabled: false },
   };
   const [formState, setFormState] = useState(initState);
   const [madeChanges, setMadeChanges] = useState(false);
@@ -84,12 +84,12 @@ const Services = ({
       formState.useOpenSCAP.value !== defaults.useOpenSCAP ||
         formState.enableCloudConnector.value !==
           defaults.enableCloudConnector ||
-        formState.hasInsights.value !== defaults.hasInsights
+        formState.apply_state.value !== defaults.apply_state
     );
     onChange({
       useOpenSCAP: formState.useOpenSCAP.value,
       enableCloudConnector: formState.enableCloudConnector.value,
-      hasInsights: formState.hasInsights.value,
+      apply_state: formState.apply_state.value,
     });
   }, [formState]);
 
@@ -272,7 +272,7 @@ Services.propTypes = {
   setMadeChanges: propTypes.func.isRequired,
   defaults: propTypes.shape({
     useOpenSCAP: propTypes.bool,
-    hasInsights: propTypes.bool,
+    apply_state: propTypes.bool,
     enableCloudConnector: propTypes.bool,
   }),
   onChange: propTypes.func.isRequired,
@@ -285,7 +285,7 @@ Services.propTypes = {
 Services.defaultProps = {
   defaults: {
     useOpenSCAP: false,
-    hasInsights: false,
+    apply_state: false,
     enableCloudConnector: false,
   },
 };

--- a/src/Components/Services/permissionsConfig.js
+++ b/src/Components/Services/permissionsConfig.js
@@ -12,14 +12,14 @@ export const permissions = [
     ],
   },
   {
-    id: 'hasInsights',
+    id: 'apply_state',
     name: 'Allow remote host configuration to manage the configuration of Red Hat services',
     description:
       'Based on changes users make in this settings area, the remote host configuration tool can push Ansible Playbooks to connected systems to update their configutaions. This includes turning these configurations on and off, based on selections.',
     links: [
       {
         name: 'View configuration manager playbooks',
-        link: 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_rhel_resource_optimization_with_insights_for_red_hat_enterprise_linux/index',
+        link: 'https://github.com/RedHatInsights/config-manager/tree/master/playbooks',
       },
     ],
   },

--- a/src/Routes/Dashboard/index.js
+++ b/src/Routes/Dashboard/index.js
@@ -64,11 +64,11 @@ const SamplePage = () => {
   const activeStateLoaded = useSelector(
     ({ activeStateReducer }) => activeStateReducer?.loaded
   );
-  const { useOpenSCAP, enableCloudConnector, hasInsights } = useSelector(
+  const { useOpenSCAP, enableCloudConnector, apply_state } = useSelector(
     ({ activeStateReducer }) => ({
       useOpenSCAP: activeStateReducer?.values?.useOpenSCAP,
       enableCloudConnector: activeStateReducer?.values?.enableCloudConnector,
-      hasInsights: activeStateReducer?.values?.hasInsights,
+      apply_state: activeStateReducer?.values?.apply_state,
     }),
     shallowEqual
   );
@@ -164,7 +164,7 @@ const SamplePage = () => {
               defaults={{
                 useOpenSCAP,
                 enableCloudConnector,
-                hasInsights,
+                apply_state,
               }}
               onChange={(data) => {
                 dataRef.current = data;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -11,17 +11,25 @@ export const configApi = new DefaultApi(
   instance
 );
 
+const updateManager = (apply_state) => {
+  return instance.post(`${CONNECTOR_API_BASE}/manage`, apply_state, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};
+
 export const updateCurrState = ({
   useOpenSCAP,
   enableCloudConnector,
-  hasInsights,
+  apply_state,
 }) => {
-  return configApi.updateStates({
-    compliance_openscap: useOpenSCAP ? 'enabled' : 'disabled',
-    insights:
-      useOpenSCAP || enableCloudConnector || hasInsights
-        ? 'enabled'
-        : 'disabled',
-    remediations: enableCloudConnector ? 'enabled' : 'disabled',
-  });
+  return Promise.all([
+    configApi.updateStates({
+      compliance_openscap: useOpenSCAP ? 'enabled' : 'disabled',
+      insights: 'enabled',
+      remediations: enableCloudConnector ? 'enabled' : 'disabled',
+    }),
+    updateManager(apply_state),
+  ]);
 };

--- a/src/store/actions.test.js
+++ b/src/store/actions.test.js
@@ -23,6 +23,7 @@ describe('actions', () => {
 
   test('saveCurrState', async () => {
     mock.onPost('/api/config-manager/v1/states').reply(200, {});
+    mock.onPost('/api/config-manager/v1/manage').reply(200, {});
     const action = saveCurrState({});
     await action.payload;
     expect(action.type).toBe('SET_CURR_STATE');

--- a/src/store/currStateReducer.js
+++ b/src/store/currStateReducer.js
@@ -17,6 +17,7 @@ const currStateFulfilled = (state, { payload }) => ({
     useOpenSCAP: payload?.state?.compliance_openscap === 'enabled',
     enableCloudConnector: payload?.state?.remediations === 'enabled',
     hasInsights: payload?.state?.insights === 'enabled',
+    apply_state: payload?.apply_state,
   },
 });
 

--- a/src/store/currStateReducer.test.js
+++ b/src/store/currStateReducer.test.js
@@ -55,6 +55,7 @@ describe('currStateReducer', () => {
           state: {
             insights: 'enabled',
           },
+          apply_state: true,
         },
       })
     ).toMatchObject({
@@ -63,6 +64,7 @@ describe('currStateReducer', () => {
         useOpenSCAP: false,
         enableCloudConnector: false,
         hasInsights: true,
+        apply_state: true,
       },
     });
   });


### PR DESCRIPTION
It Fixes the API request to change the settings. Please closely test against [the comments](https://issues.redhat.com/browse/ESSNTL-3099) by Jeremy Audet.

1. `state.insights` should always be enabled whenever the user makes a change in the config
2. The 'View configuration manager playbooks' link should lead to https://github.com/RedHatInsights/config-manager/tree/master/playbooks
3. The three visible configurations should behave independently
4. When the user changes 

- the first configuration, should only affect the `.state.remediation` 
- the second configuration, should only affect `.apply_state`
- the third configuration, should only affect `.state.compliance_openscap`