### PR TITLE
Fix typo in Remote Host Configuration Manager page

### DIFF
--- a/src/Components/Services/permissionsConfig.js
+++ b/src/Components/Services/permissionsConfig.js
@@ -15,7 +15,7 @@ export const permissions = [
     id: 'apply_state',
     name: 'Allow remote host configuration to manage the configuration of Red Hat services',
     description:
-      'Based on changes users make in this settings area, the remote host configuration tool can push Ansible Playbooks to connected systems to update their configutaions. This includes turning these configurations on and off, based on selections.',
+      'Based on changes users make in this settings area, the remote host configuration tool can push Ansible Playbooks to connected systems to update their configurations. This includes turning these configurations on and off, based on selections.',
     links: [
       {
         name: 'View configuration manager playbooks',


### PR DESCRIPTION
s/configutaions/configurations/

Signed-off-by: Gael Chamoulaud (Strider) <gchamoul@redhat.com>