### PR TITLE
Change frontend name to connector to match everything else

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -6,7 +6,7 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: Frontend
     metadata:
-      name: sed-frontend
+      name: connector
     spec:
       envName: ${ENV_NAME}
       title: "Manage configuration"


### PR DESCRIPTION
This PR changes the frontend object name from sed-frontend to connector to try and maintain consistency