### PR TITLE
Add routePrefix to frontend deploy YAML

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -10,6 +10,7 @@ objects:
     spec:
       envName: ${ENV_NAME}
       title: "Manage configuration"
+      routePrefix: settings
       deploymentRepo: https://github.com/RedHatInsights/sed-frontend
       API:
         versions:


### PR DESCRIPTION
This PR adds the new routePrefix config option so your app will correctly hang off /settings rather than /apps