### PR TITLE
Fix fed-modules path in deploy YAML

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -30,7 +30,7 @@ objects:
               title: Activation Keys
               href: /settings/connector/activation-keys
       module:
-        manifestLocation: /apps/connector/fed-mods.json
+        manifestLocation: /settings/connector/fed-mods.json
         modules:
           - id: connector
             module: ./RootApp


### PR DESCRIPTION
This updates the deploy YAML to change the path for the federated modules, because it was set to apps rather than settings