### PR TITLE
fix: downloading playbook is fixed by using correct api-client function

### DIFF
--- a/src/Components/ConnectLog/LogsTable.js
+++ b/src/Components/ConnectLog/LogsTable.js
@@ -68,7 +68,7 @@ const rowsMapper = (results, opened) =>
                 isInline
                 onClick={() => {
                   (async () => {
-                    const data = await configApi.getPlaybookById(id);
+                    const data = await configApi.getPlaybook(id);
                     downloadFile(data);
                   })();
                 }}


### PR DESCRIPTION
This fixes the download feature on 'View logs' modal.

To test:

1. Visit the 'Remote host configuration' app.
2. open 'View log' modal on the top right'
3. click on the 'Download' button on the table.
4. Observe a playbook is downloaded.