### PR TITLE
fix(ESSNTL-3955): fixes the rhcd filter on systems tab

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,7 @@
 extends: 
   - "@redhat-cloud-services/eslint-config-redhat-cloud-services"
   - "plugin:cypress/recommended"
+root: true
 globals:
   insights: 'readonly'
   shallow: readonly

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -15,6 +15,7 @@ const webpackProxy = {
     ? ['/beta/settings/connector']
     : ['/settings/connector'],
   // routes: {
+  //   '/apps/inventory': { host: 'http://stage.foo.redhat.com:8002' },
   //   '/beta/config': {
   //     host: 'http://localhost:8889',
   //   },

--- a/src/Components/ConnectLog/SystemsTable.js
+++ b/src/Components/ConnectLog/SystemsTable.js
@@ -10,21 +10,18 @@ const SystemsTable = () => {
       hasCheckbox={false}
       columns={(defaultColumns) => defaultColumns}
       getEntities={async (_i, config, tags, defaultGetEntities) => {
-        const { rhcdFilter = [] } = config?.filters || {};
-
-        //overrides the rhcd from Inventory module if that filter does not exist
-        config.filter = {
-          system_profile: {
-            rhc_client_id: rhcdFilter.length !== 0 ? rhcdFilter : 'not_nil',
-          },
-        };
-
-        const data = await defaultGetEntities(undefined, config, tags);
-        return data;
+        return await defaultGetEntities(undefined, config, tags);
       }}
       onRowClick={(_e, id) =>
         (window.location.href = `./insights/inventory/${id}`)
       }
+      customFilters={{
+        filters: [
+          {
+            rhcdFilter: ['not_nil'],
+          },
+        ],
+      }}
       onLoad={({ mergeWithEntities }) => {
         register?.({
           ...mergeWithEntities(),

--- a/src/Components/ConnectLog/SystemsTable.js
+++ b/src/Components/ConnectLog/SystemsTable.js
@@ -10,11 +10,15 @@ const SystemsTable = () => {
       hasCheckbox={false}
       columns={(defaultColumns) => defaultColumns}
       getEntities={async (_i, config, tags, defaultGetEntities) => {
+        const { rhcdFilter = [] } = config?.filters || {};
+
+        //overrides the rhcd from Inventory module if that filter does not exist
         config.filter = {
           system_profile: {
-            rhc_client_id: 'not_nil',
+            rhc_client_id: rhcdFilter.length !== 0 ? rhcdFilter : 'not_nil',
           },
         };
+
         const data = await defaultGetEntities(undefined, config, tags);
         return data;
       }}


### PR DESCRIPTION
# Description

Associated Jira ticket: # [ESSNTL-3955](https://issues.redhat.com/browse/ESSNTL-3955)

This fixes the RHC filter in the Systems tab on the 'View logs' modal. It sets the default 'not_nil' RHC value if that filter is not set by the Inventory module.  

# How to test the PR

1. Click on the 'View logs' button on the top right to open the modal
2. Navigate to the 'Systems' tab
3. Observe that the API request includes rhc_client_id set to not_nil
4. Observe that the RHC filter in the filters dropdown works as expected.

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
