### PR TITLE
TEAMNADO-4639: Activation Key Details - Only show repos not enabled by default when adding new repos

### DIFF
--- a/src/hooks/useAvailableRepositories.js
+++ b/src/hooks/useAvailableRepositories.js
@@ -7,7 +7,7 @@ const fetchAdditionalRepositories = async (keyName) => {
   const token = await window.insights.chrome.auth.getToken();
 
   const response = await fetch(
-    `/api/rhsm/v2/activation_keys/${keyName}/available_repositories`,
+    `/api/rhsm/v2/activation_keys/${keyName}/available_repositories?default=Disabled`,
     {
       headers: { Authorization: `Bearer ${token}` },
     }


### PR DESCRIPTION

Updated available_repos hook to filter with default=Disabled