### PR TITLE
Bug fix: 0 in empty state

### DIFF
--- a/src/Components/ActivationKeys/ActivationKeys.js
+++ b/src/Components/ActivationKeys/ActivationKeys.js
@@ -121,7 +121,7 @@ const ActivationKeys = () => {
         <Main>
           <PageSection variant={PageSectionVariants.light}>
             {isLoading && <Loading />}
-            {!isLoading && !error && data.length && (
+            {!isLoading && !error && data.length > 0 && (
               <>
                 <ActionGroup>
                   <CreateActivationKeyButton onClick={handleModalToggle} />


### PR DESCRIPTION
data.length returns a 0 which is falsy and prevents the next chunk from rendering, however it does return and render the 0. 