### PR TITLE
Use proper document title

### DIFF
--- a/src/Components/ActivationKeys/ActivationKeys.js
+++ b/src/Components/ActivationKeys/ActivationKeys.js
@@ -17,6 +17,7 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import ActivationKeysTable from '../ActivationKeysTable';
 import { useQueryClient } from 'react-query';
 import NoAccessView from './no-access';
@@ -29,6 +30,8 @@ import CreateActivationKeyButton from './CreateActivationKeyButton';
 import DeleteActivationKeyConfirmationModal from '../Modals/DeleteActivationKeyConfirmationModal';
 import ActivationKeysDocsPopover from '../ActivationKeysDocsPopover';
 const ActivationKeys = () => {
+  const { updateDocumentTitle } = useChrome();
+  updateDocumentTitle?.('Activation Keys - Remote Host Configuration');
   const queryClient = useQueryClient();
   const user = queryClient.getQueryData('user');
   const { isLoading, error, data } = useActivationKeys();

--- a/src/Routes/Dashboard/index.js
+++ b/src/Routes/Dashboard/index.js
@@ -26,6 +26,7 @@ import React, {
 } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Route, useHistory } from 'react-router-dom';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import pckg from '../../../package.json';
 import ConfirmChangesModal from '../../Components/ConfirmChangesModal';
 import Services from '../../Components/Services/Services';
@@ -49,6 +50,8 @@ const ConnectLog = lazy(() =>
 );
 
 const SamplePage = () => {
+  const { updateDocumentTitle } = useChrome();
+  updateDocumentTitle?.('Manage Configuration - Remote Host Configuration');
   const history = useHistory();
   const { getRegistry } = useContext(RegistryContext);
   const [confirmChangesOpen, setConfirmChangesOpen] = useState(false);


### PR DESCRIPTION
# Description

Associated Jira ticket: #RHCLOUD-25356

We want to adjust all browser titles. This PR uses chrome's updateDocumentTitle and sets it to `Activation Keys - Remote Host Configuration` and `Manage Configuration - Remote Host Configuration`.


# How to test the PR

Run the app, open either Manage configuration or Activation keys and check browser title to change.
