### PR TITLE
Fix constant ActivationKey page re-mount

### DIFF
--- a/src/Components/ActivationKey/ActivationKey.js
+++ b/src/Components/ActivationKey/ActivationKey.js
@@ -76,94 +76,90 @@ const ActivationKey = () => {
   const editModalDescription =
     'System purpose values are used by the subscriptions service to help filter and identify hosts. Setting values for these attributes is optional, but doing so ensures that subscriptions reporting accurately reflects the system. Only those values available to your account are shown.';
 
-  const Page = () => {
-    return (
-      <React.Fragment>
-        <PageHeader>
-          <Level>
-            <LevelItem>
-              <Breadcrumbs {...breadcrumbs} />
-              <PageHeaderTitle title={id} />
-              <TextContent>
-                <Text component={TextVariants.p}>{description}</Text>
-              </TextContent>
-            </LevelItem>
-            <LevelItem>
-              {user.rbacPermissions.canWriteActivationKeys ? (
-                <DeleteButton onClick={handleDeleteActivationKeyModalToggle} />
-              ) : (
-                <NoAccessPopover content={DeleteButton} />
-              )}
-            </LevelItem>
-          </Level>
-        </PageHeader>
-        {isKeyLoading && !keyError ? (
-          <Loading />
-        ) : (
-          <React.Fragment>
-            <Main>
-              <Grid hasGutter>
-                <GridItem span={12}>
-                  <Gallery
-                    hasGutter
-                    minWidths={{
-                      default: '40%',
-                    }}
-                  >
-                    <GalleryItem>
-                      <SystemPurposeCard
-                        activationKey={activationKey}
-                        actionHandler={handleEditActivationKeyModalToggle}
-                      />
-                    </GalleryItem>
-                    <GalleryItem>
-                      <WorkloadCard
-                        activationKey={activationKey}
-                        actionHandler={handleEditReleaseVersionModalToggle}
-                      />
-                    </GalleryItem>
-                  </Gallery>
-                </GridItem>
-                <GridItem span={12}>
-                  <AdditionalRepositoriesCard
-                    activationKey={activationKey}
-                    actionHandler={handleEditActivationKeyModalToggle}
-                  />
-                </GridItem>
-              </Grid>
-            </Main>
-            <DeleteActivationKeyConfirmationModal
-              handleModalToggle={handleDeleteActivationKeyModalToggle}
-              isOpen={isDeleteActivationKeyModalOpen}
-              name={id}
-            />
-            <EditActivationKeyModal
-              title="Edit system purpose"
-              description={editModalDescription}
-              isOpen={isEditActivationKeyModalOpen}
-              handleModalToggle={handleEditActivationKeyModalToggle}
-              activationKeyName={id}
-              systemPurposeOnly={true}
-              modalSize="small"
-            />
-            <EditReleaseVersionModal
-              isOpen={isEditReleaseVersionModalOpen}
-              onClose={handleEditReleaseVersionModalToggle}
-              releaseVersions={releaseVersions}
-              areReleaseVersionsLoading={areReleaseVersionsLoading}
-              activationKey={activationKey}
-            />
-          </React.Fragment>
-        )}
-      </React.Fragment>
-    );
-  };
-
-  if (user.rbacPermissions.canReadActivationKeys) {
-    return <Page />;
-  } else {
+  if (!user.rbacPermissions.canReadActivationKeys) {
     return <NoAccessView />;
   }
+
+  return (
+    <React.Fragment>
+      <PageHeader>
+        <Level>
+          <LevelItem>
+            <Breadcrumbs {...breadcrumbs} />
+            <PageHeaderTitle title={id} />
+            <TextContent>
+              <Text component={TextVariants.p}>{description}</Text>
+            </TextContent>
+          </LevelItem>
+          <LevelItem>
+            {user.rbacPermissions.canWriteActivationKeys ? (
+              <DeleteButton onClick={handleDeleteActivationKeyModalToggle} />
+            ) : (
+              <NoAccessPopover content={DeleteButton} />
+            )}
+          </LevelItem>
+        </Level>
+      </PageHeader>
+      {isKeyLoading && !keyError ? (
+        <Loading />
+      ) : (
+        <React.Fragment>
+          <Main>
+            <Grid hasGutter>
+              <GridItem span={12}>
+                <Gallery
+                  hasGutter
+                  minWidths={{
+                    default: '40%',
+                  }}
+                >
+                  <GalleryItem>
+                    <SystemPurposeCard
+                      activationKey={activationKey}
+                      actionHandler={handleEditActivationKeyModalToggle}
+                    />
+                  </GalleryItem>
+                  <GalleryItem>
+                    <WorkloadCard
+                      activationKey={activationKey}
+                      actionHandler={handleEditReleaseVersionModalToggle}
+                    />
+                  </GalleryItem>
+                </Gallery>
+              </GridItem>
+              <GridItem span={12}>
+                <AdditionalRepositoriesCard
+                  activationKey={activationKey}
+                  actionHandler={handleEditActivationKeyModalToggle}
+                />
+              </GridItem>
+            </Grid>
+          </Main>
+        </React.Fragment>
+      )}
+      <DeleteActivationKeyConfirmationModal
+        handleModalToggle={handleDeleteActivationKeyModalToggle}
+        isOpen={isDeleteActivationKeyModalOpen}
+        name={id}
+      />
+      <EditActivationKeyModal
+        title="Edit system purpose"
+        description={editModalDescription}
+        isOpen={isEditActivationKeyModalOpen}
+        handleModalToggle={handleEditActivationKeyModalToggle}
+        activationKeyName={id}
+        systemPurposeOnly={true}
+        modalSize="small"
+      />
+      <EditReleaseVersionModal
+        isOpen={isEditReleaseVersionModalOpen}
+        onClose={handleEditReleaseVersionModalToggle}
+        releaseVersions={releaseVersions}
+        areReleaseVersionsLoading={areReleaseVersionsLoading}
+        activationKey={activationKey}
+      />
+    </React.Fragment>
+  );
 };
 
 export default withRouter(ActivationKey);


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-26412

The `Page` component was re-created on each render causing every component within its tree to be `re-mounted` and its internal state to be reset which cause the modal to "re-open". In reality, it never closed.