### PR TITLE
Add workload selection, success page, and name validation

### DIFF
--- a/src/Components/Modals/__tests__/CreateActivationKeyWizard.test.js
+++ b/src/Components/Modals/__tests__/CreateActivationKeyWizard.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import CreateActivationKeyWizard from '../CreateActivationKeyWizard';
 import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import useCreateActivationKey from '../../../hooks/useCreateActivationKey';
 
@@ -15,7 +16,7 @@ useCreateActivationKey.mockReturnValue({
 });
 
 describe('Create Activation Key Wizard', () => {
-  const pages = [1, 2, 3, 4];
+  const pages = [1, 2, 3, 4, 5];
   pages.forEach((page) => {
     it(`renders page ${page} correctly`, () => {
       const { container } = render(
@@ -51,7 +52,7 @@ describe('Create Activation Key Wizard', () => {
     expect(document.body).toMatchSnapshot();
   });
 
-  it('Saves data', () => {
+  it('Saves data', async () => {
     const { container } = render(
       <QueryClientProvider client={queryClient}>
         <CreateActivationKeyWizard onClose={() => {}} isOpen={true} />
@@ -61,6 +62,6 @@ describe('Create Activation Key Wizard', () => {
       fireEvent.click(container.nextSibling.querySelector('.pf-m-primary'));
     }
 
-    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(document.body).toMatchSnapshot();
   });
 });

--- a/src/Components/Modals/__tests__/__snapshots__/CreateActivationKeyModal.test.js.snap
+++ b/src/Components/Modals/__tests__/__snapshots__/CreateActivationKeyModal.test.js.snap
@@ -308,10 +308,12 @@ exports[`Create Activation Key Modal renders the wizard when feature flag is ena
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-2"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="1"
                       >
                         Workload
@@ -322,10 +324,12 @@ exports[`Create Activation Key Modal renders the wizard when feature flag is ena
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-3"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="2"
                       >
                         System purpose
@@ -336,10 +340,12 @@ exports[`Create Activation Key Modal renders the wizard when feature flag is ena
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-4"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="3"
                       >
                         Review
@@ -432,11 +438,12 @@ exports[`Create Activation Key Modal renders the wizard when feature flag is ena
                 class="pf-c-wizard__footer"
               >
                 <button
-                  aria-disabled="false"
-                  class="pf-c-button pf-m-primary"
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-primary pf-m-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-primary-2"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
+                  disabled=""
                   type="submit"
                 >
                   Next

--- a/src/Components/Modals/__tests__/__snapshots__/CreateActivationKeyWizard.test.js.snap
+++ b/src/Components/Modals/__tests__/__snapshots__/CreateActivationKeyWizard.test.js.snap
@@ -15,138 +15,14 @@ exports[`Create Activation Key Wizard Confirms on close one next has been clicke
         class="pf-l-bullseye"
       >
         <div
-          aria-describedby="pf-modal-part-7"
           aria-label="Create activation key wizard"
-          aria-labelledby="pf-modal-part-5 pf-modal-part-6"
-          aria-modal="true"
-          class="pf-c-modal-box pf-m-warning pf-m-sm"
-          data-ouia-component-id="OUIA-Generated-Modal-large-6"
-          data-ouia-component-type="PF4/ModalContent"
-          data-ouia-safe="true"
-          id="pf-modal-part-5"
-          role="dialog"
-        >
-          <button
-            aria-disabled="false"
-            aria-label="Close"
-            class="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Modal-large-6-ModalBoxCloseButton"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe="true"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 352 512"
-              width="1em"
-            >
-              <path
-                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-              />
-            </svg>
-          </button>
-          <header
-            class="pf-c-modal-box__header"
-          >
-            <h1
-              class="pf-c-modal-box__title pf-m-icon"
-              id="pf-modal-part-6"
-            >
-              <span
-                class="pf-c-modal-box__title-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 576 512"
-                  width="1em"
-                >
-                  <path
-                    d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="pf-u-screen-reader"
-              >
-                Warning alert:
-              </span>
-              <span
-                class="pf-c-modal-box__title-text"
-              >
-                Exit activation key creation?
-              </span>
-            </h1>
-          </header>
-          <div
-            class="pf-c-modal-box__body"
-            id="pf-modal-part-7"
-          >
-            <p>
-              All inputs will be discarded.
-            </p>
-          </div>
-          <footer
-            class="pf-c-modal-box__footer"
-          >
-            <button
-              aria-disabled="false"
-              class="pf-c-button pf-m-primary"
-              data-ouia-component-id="OUIA-Generated-Button-primary-7"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              type="button"
-            >
-              Exit
-            </button>
-            <button
-              aria-disabled="false"
-              class="pf-c-button pf-m-link"
-              data-ouia-component-id="OUIA-Generated-Button-link-7"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              type="button"
-            >
-              Stay
-            </button>
-          </footer>
-        </div>
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has been done 1`] = `
-<body
-  class="pf-c-backdrop__open"
->
-  <div
-    aria-hidden="true"
-  />
-  <div>
-    <div
-      class="pf-c-backdrop"
-    >
-      <div
-        class="pf-l-bullseye"
-      >
-        <div
-          aria-label="Create activation key wizard"
-          aria-labelledby="pf-modal-part-4"
+          aria-labelledby="pf-modal-part-6"
           aria-modal="true"
           class="pf-c-modal-box pf-m-lg"
-          data-ouia-component-id="OUIA-Generated-Modal-large-5"
+          data-ouia-component-id="OUIA-Generated-Modal-large-7"
           data-ouia-component-type="PF4/ModalContent"
           data-ouia-safe="true"
-          id="pf-modal-part-4"
+          id="pf-modal-part-6"
           role="dialog"
         >
           
@@ -161,7 +37,7 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                 aria-disabled="false"
                 aria-label="Close"
                 class="pf-c-button pf-m-plain pf-c-wizard__close"
-                data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                data-ouia-component-id="OUIA-Generated-Button-plain-7"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -186,7 +62,7 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                 data-ouia-component-id="OUIA-Generated-Title-13"
                 data-ouia-component-type="PF4/Title"
                 data-ouia-safe="true"
-                id="pf-wizard-title-4"
+                id="pf-wizard-title-6"
               >
                 Create activation key
               </h2>
@@ -238,9 +114,9 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
               >
                 <nav
                   aria-label="Create activation key steps"
-                  aria-labelledby="pf-wizard-title-4"
+                  aria-labelledby="pf-wizard-title-6"
                   class="pf-c-wizard__nav"
-                  data-ouia-component-id="OUIA-Generated-WizardNav-5"
+                  data-ouia-component-id="OUIA-Generated-WizardNav-7"
                   data-ouia-component-type="PF4/WizardNav"
                   data-ouia-safe="true"
                 >
@@ -253,7 +129,7 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                       <button
                         aria-current="step"
                         class="pf-c-wizard__nav-link pf-m-current"
-                        data-ouia-component-id="OUIA-Generated-WizardNavItem-17"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-25"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
                       >
@@ -265,10 +141,12 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
-                        data-ouia-component-id="OUIA-Generated-WizardNavItem-18"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-26"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="1"
                       >
                         Workload
@@ -279,10 +157,12 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
-                        data-ouia-component-id="OUIA-Generated-WizardNavItem-19"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-27"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="2"
                       >
                         System purpose
@@ -293,10 +173,12 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
-                        data-ouia-component-id="OUIA-Generated-WizardNavItem-20"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-28"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="3"
                       >
                         Review
@@ -306,7 +188,7 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                 </nav>
                 <div
                   aria-label="Create activation key content"
-                  aria-labelledby="pf-wizard-title-4"
+                  aria-labelledby="pf-wizard-title-6"
                   class="pf-c-wizard__main"
                 >
                   <div
@@ -322,7 +204,7 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                     </h2>
                     <p
                       class="pf-u-mb-xl"
-                      data-ouia-component-id="OUIA-Generated-Text-9"
+                      data-ouia-component-id="OUIA-Generated-Text-7"
                       data-ouia-component-type="PF4/Text"
                       data-ouia-safe="true"
                       data-pf-content="true"
@@ -364,7 +246,7 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                           <input
                             aria-invalid="false"
                             class="pf-c-form-control"
-                            data-ouia-component-id="OUIA-Generated-TextInputBase-5"
+                            data-ouia-component-id="OUIA-Generated-TextInputBase-7"
                             data-ouia-component-type="PF4/TextInput"
                             data-ouia-safe="true"
                             id="activation-key-name"
@@ -389,11 +271,12 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                 class="pf-c-wizard__footer"
               >
                 <button
-                  aria-disabled="false"
-                  class="pf-c-button pf-m-primary"
-                  data-ouia-component-id="OUIA-Generated-Button-primary-5"
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-primary pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-primary-7"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
+                  disabled=""
                   type="submit"
                 >
                   Next
@@ -401,7 +284,7 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                 <button
                   aria-disabled="true"
                   class="pf-c-button pf-m-secondary pf-m-disabled"
-                  data-ouia-component-id="OUIA-Generated-Button-secondary-5"
+                  data-ouia-component-id="OUIA-Generated-Button-secondary-7"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
                   disabled=""
@@ -415,7 +298,639 @@ exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has 
                   <button
                     aria-disabled="false"
                     class="pf-c-button pf-m-link"
-                    data-ouia-component-id="OUIA-Generated-Button-link-5"
+                    data-ouia-component-id="OUIA-Generated-Button-link-7"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Create Activation Key Wizard Doesn't confirm on close when nothing has been done 1`] = `
+<body
+  class="pf-c-backdrop__open"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div>
+    <div
+      class="pf-c-backdrop"
+    >
+      <div
+        class="pf-l-bullseye"
+      >
+        <div
+          aria-label="Create activation key wizard"
+          aria-labelledby="pf-modal-part-5"
+          aria-modal="true"
+          class="pf-c-modal-box pf-m-lg"
+          data-ouia-component-id="OUIA-Generated-Modal-large-6"
+          data-ouia-component-type="PF4/ModalContent"
+          data-ouia-safe="true"
+          id="pf-modal-part-5"
+          role="dialog"
+        >
+          
+          <div
+            class="pf-c-wizard"
+            style="height: 400px;"
+          >
+            <div
+              class="pf-c-wizard__header"
+            >
+              <button
+                aria-disabled="false"
+                aria-label="Close"
+                class="pf-c-button pf-m-plain pf-c-wizard__close"
+                data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </button>
+              <h2
+                aria-label="Create activation key"
+                class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                data-ouia-component-id="OUIA-Generated-Title-11"
+                data-ouia-component-type="PF4/Title"
+                data-ouia-safe="true"
+                id="pf-wizard-title-5"
+              >
+                Create activation key
+              </h2>
+              
+            </div>
+            <button
+              aria-expanded="false"
+              aria-label="Wizard Toggle"
+              class="pf-c-wizard__toggle"
+            >
+              <span
+                class="pf-c-wizard__toggle-list"
+              >
+                <span
+                  class="pf-c-wizard__toggle-list-item"
+                >
+                  <span
+                    class="pf-c-wizard__toggle-num"
+                  >
+                    1
+                  </span>
+                   
+                  Name
+                </span>
+              </span>
+              <span
+                class="pf-c-wizard__toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <div
+              class="pf-c-wizard__outer-wrap"
+            >
+              <div
+                class="pf-c-wizard__inner-wrap"
+              >
+                <nav
+                  aria-label="Create activation key steps"
+                  aria-labelledby="pf-wizard-title-5"
+                  class="pf-c-wizard__nav"
+                  data-ouia-component-id="OUIA-Generated-WizardNav-6"
+                  data-ouia-component-type="PF4/WizardNav"
+                  data-ouia-safe="true"
+                >
+                  <ol
+                    class="pf-c-wizard__nav-list"
+                  >
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="step"
+                        class="pf-c-wizard__nav-link pf-m-current"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-21"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                      >
+                        Name
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-22"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                        disabled=""
+                        id="1"
+                      >
+                        Workload
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-23"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                        disabled=""
+                        id="2"
+                      >
+                        System purpose
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-24"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                        disabled=""
+                        id="3"
+                      >
+                        Review
+                      </button>
+                    </li>
+                  </ol>
+                </nav>
+                <div
+                  aria-label="Create activation key content"
+                  aria-labelledby="pf-wizard-title-5"
+                  class="pf-c-wizard__main"
+                >
+                  <div
+                    class="pf-c-wizard__main-body"
+                  >
+                    <h2
+                      class="pf-c-title pf-m-xl pf-u-mb-sm"
+                      data-ouia-component-id="OUIA-Generated-Title-12"
+                      data-ouia-component-type="PF4/Title"
+                      data-ouia-safe="true"
+                    >
+                      Name key
+                    </h2>
+                    <p
+                      class="pf-u-mb-xl"
+                      data-ouia-component-id="OUIA-Generated-Text-6"
+                      data-ouia-component-type="PF4/Text"
+                      data-ouia-safe="true"
+                      data-pf-content="true"
+                    >
+                      This name cannot be modified after the activation key is created.
+                    </p>
+                    <form
+                      class="pf-c-form"
+                      novalidate=""
+                    >
+                      <div
+                        class="pf-c-form__group"
+                      >
+                        <div
+                          class="pf-c-form__group-label"
+                        >
+                          <label
+                            class="pf-c-form__label"
+                            for="activation-key-name"
+                          >
+                            <span
+                              class="pf-c-form__label-text"
+                            >
+                              Name
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="pf-c-form__label-required"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
+                           
+                        </div>
+                        <div
+                          class="pf-c-form__group-control"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="pf-c-form-control"
+                            data-ouia-component-id="OUIA-Generated-TextInputBase-6"
+                            data-ouia-component-type="PF4/TextInput"
+                            data-ouia-safe="true"
+                            id="activation-key-name"
+                            required=""
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            aria-live="polite"
+                            class="pf-c-form__helper-text"
+                            id="activation-key-name-helper"
+                          >
+                            Your activation key name must be unique and must contain only numbers, letters, underscores, and hyphens.
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </div>
+              <footer
+                class="pf-c-wizard__footer"
+              >
+                <button
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-primary pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-primary-6"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  type="submit"
+                >
+                  Next
+                </button>
+                <button
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-secondary pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-secondary-6"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  type="button"
+                >
+                  Back
+                </button>
+                <div
+                  class="pf-c-wizard__footer-cancel"
+                >
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-6"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Create Activation Key Wizard Saves data 1`] = `
+<body
+  class="pf-c-backdrop__open"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div>
+    <div
+      class="pf-c-backdrop"
+    >
+      <div
+        class="pf-l-bullseye"
+      >
+        <div
+          aria-label="Create activation key wizard"
+          aria-labelledby="pf-modal-part-7"
+          aria-modal="true"
+          class="pf-c-modal-box pf-m-lg"
+          data-ouia-component-id="OUIA-Generated-Modal-large-8"
+          data-ouia-component-type="PF4/ModalContent"
+          data-ouia-safe="true"
+          id="pf-modal-part-7"
+          role="dialog"
+        >
+          
+          <div
+            class="pf-c-wizard"
+            style="height: 400px;"
+          >
+            <div
+              class="pf-c-wizard__header"
+            >
+              <button
+                aria-disabled="false"
+                aria-label="Close"
+                class="pf-c-button pf-m-plain pf-c-wizard__close"
+                data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </button>
+              <h2
+                aria-label="Create activation key"
+                class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                data-ouia-component-id="OUIA-Generated-Title-15"
+                data-ouia-component-type="PF4/Title"
+                data-ouia-safe="true"
+                id="pf-wizard-title-7"
+              >
+                Create activation key
+              </h2>
+              
+            </div>
+            <button
+              aria-expanded="false"
+              aria-label="Wizard Toggle"
+              class="pf-c-wizard__toggle"
+            >
+              <span
+                class="pf-c-wizard__toggle-list"
+              >
+                <span
+                  class="pf-c-wizard__toggle-list-item"
+                >
+                  <span
+                    class="pf-c-wizard__toggle-num"
+                  >
+                    1
+                  </span>
+                   
+                  Name
+                </span>
+              </span>
+              <span
+                class="pf-c-wizard__toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <div
+              class="pf-c-wizard__outer-wrap"
+            >
+              <div
+                class="pf-c-wizard__inner-wrap"
+              >
+                <nav
+                  aria-label="Create activation key steps"
+                  aria-labelledby="pf-wizard-title-7"
+                  class="pf-c-wizard__nav"
+                  data-ouia-component-id="OUIA-Generated-WizardNav-8"
+                  data-ouia-component-type="PF4/WizardNav"
+                  data-ouia-safe="true"
+                >
+                  <ol
+                    class="pf-c-wizard__nav-list"
+                  >
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="step"
+                        class="pf-c-wizard__nav-link pf-m-current"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-29"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                      >
+                        Name
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-30"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                        disabled=""
+                        id="1"
+                      >
+                        Workload
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-31"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                        disabled=""
+                        id="2"
+                      >
+                        System purpose
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-32"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                        disabled=""
+                        id="3"
+                      >
+                        Review
+                      </button>
+                    </li>
+                  </ol>
+                </nav>
+                <div
+                  aria-label="Create activation key content"
+                  aria-labelledby="pf-wizard-title-7"
+                  class="pf-c-wizard__main"
+                >
+                  <div
+                    class="pf-c-wizard__main-body"
+                  >
+                    <h2
+                      class="pf-c-title pf-m-xl pf-u-mb-sm"
+                      data-ouia-component-id="OUIA-Generated-Title-16"
+                      data-ouia-component-type="PF4/Title"
+                      data-ouia-safe="true"
+                    >
+                      Name key
+                    </h2>
+                    <p
+                      class="pf-u-mb-xl"
+                      data-ouia-component-id="OUIA-Generated-Text-8"
+                      data-ouia-component-type="PF4/Text"
+                      data-ouia-safe="true"
+                      data-pf-content="true"
+                    >
+                      This name cannot be modified after the activation key is created.
+                    </p>
+                    <form
+                      class="pf-c-form"
+                      novalidate=""
+                    >
+                      <div
+                        class="pf-c-form__group"
+                      >
+                        <div
+                          class="pf-c-form__group-label"
+                        >
+                          <label
+                            class="pf-c-form__label"
+                            for="activation-key-name"
+                          >
+                            <span
+                              class="pf-c-form__label-text"
+                            >
+                              Name
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="pf-c-form__label-required"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
+                           
+                        </div>
+                        <div
+                          class="pf-c-form__group-control"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="pf-c-form-control"
+                            data-ouia-component-id="OUIA-Generated-TextInputBase-8"
+                            data-ouia-component-type="PF4/TextInput"
+                            data-ouia-safe="true"
+                            id="activation-key-name"
+                            required=""
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            aria-live="polite"
+                            class="pf-c-form__helper-text"
+                            id="activation-key-name-helper"
+                          >
+                            Your activation key name must be unique and must contain only numbers, letters, underscores, and hyphens.
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </div>
+              <footer
+                class="pf-c-wizard__footer"
+              >
+                <button
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-primary pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-primary-8"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  type="submit"
+                >
+                  Next
+                </button>
+                <button
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-secondary pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-secondary-8"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  type="button"
+                >
+                  Back
+                </button>
+                <div
+                  class="pf-c-wizard__footer-cancel"
+                >
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-8"
                     data-ouia-component-type="PF4/Button"
                     data-ouia-safe="true"
                     type="button"
@@ -574,10 +1089,12 @@ exports[`Create Activation Key Wizard renders page 1 correctly 1`] = `
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-2"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="1"
                       >
                         Workload
@@ -588,10 +1105,12 @@ exports[`Create Activation Key Wizard renders page 1 correctly 1`] = `
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-3"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="2"
                       >
                         System purpose
@@ -602,10 +1121,12 @@ exports[`Create Activation Key Wizard renders page 1 correctly 1`] = `
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-4"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="3"
                       >
                         Review
@@ -698,11 +1219,12 @@ exports[`Create Activation Key Wizard renders page 1 correctly 1`] = `
                 class="pf-c-wizard__footer"
               >
                 <button
-                  aria-disabled="false"
-                  class="pf-c-button pf-m-primary"
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-primary pf-m-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-primary-1"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
+                  disabled=""
                   type="submit"
                 >
                   Next
@@ -824,10 +1346,10 @@ exports[`Create Activation Key Wizard renders page 2 correctly 1`] = `
                   <span
                     class="pf-c-wizard__toggle-num"
                   >
-                    2
+                    1
                   </span>
                    
-                  Workload
+                  Name
                 </span>
               </span>
               <span
@@ -869,8 +1391,8 @@ exports[`Create Activation Key Wizard renders page 2 correctly 1`] = `
                       class="pf-c-wizard__nav-item"
                     >
                       <button
-                        aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-current="step"
+                        class="pf-c-wizard__nav-link pf-m-current"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-5"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
@@ -882,11 +1404,13 @@ exports[`Create Activation Key Wizard renders page 2 correctly 1`] = `
                       class="pf-c-wizard__nav-item"
                     >
                       <button
-                        aria-current="step"
-                        class="pf-c-wizard__nav-link pf-m-current"
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-6"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="1"
                       >
                         Workload
@@ -897,10 +1421,12 @@ exports[`Create Activation Key Wizard renders page 2 correctly 1`] = `
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-7"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="2"
                       >
                         System purpose
@@ -911,10 +1437,12 @@ exports[`Create Activation Key Wizard renders page 2 correctly 1`] = `
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-8"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="3"
                       >
                         Review
@@ -932,64 +1460,74 @@ exports[`Create Activation Key Wizard renders page 2 correctly 1`] = `
                   >
                     <h2
                       class="pf-c-title pf-m-xl pf-u-mb-sm"
-                      data-ouia-component-id="OUIA-Generated-Title-5"
+                      data-ouia-component-id="OUIA-Generated-Title-4"
                       data-ouia-component-type="PF4/Title"
                       data-ouia-safe="true"
                     >
-                      Select Workload
+                      Name key
                     </h2>
                     <p
                       class="pf-u-mb-xl"
-                      data-ouia-component-id="OUIA-Generated-Text-3"
+                      data-ouia-component-id="OUIA-Generated-Text-2"
                       data-ouia-component-type="PF4/Text"
                       data-ouia-safe="true"
                       data-pf-content="true"
                     >
-                      Choose a workload option to associate an appropriate selection of repositories to the activation key. Repositories can be edited on the activation key detail page.
-                       
+                      This name cannot be modified after the activation key is created.
                     </p>
-                    <div
-                      class="pf-c-radio pf-u-mb-md"
+                    <form
+                      class="pf-c-form"
+                      novalidate=""
                     >
-                      <input
-                        aria-invalid="false"
-                        checked=""
-                        class="pf-c-radio__input"
-                        data-ouia-component-id="OUIA-Generated-Radio-1"
-                        data-ouia-component-type="PF4/Radio"
-                        data-ouia-safe="true"
-                        id="Latest release"
-                        name="Latest release"
-                        type="radio"
-                      />
-                      <label
-                        class="pf-c-radio__label"
-                        for="Latest release"
+                      <div
+                        class="pf-c-form__group"
                       >
-                        Latest release
-                      </label>
-                    </div>
-                    <div
-                      class="pf-c-radio pf-u-mb-md"
-                    >
-                      <input
-                        aria-invalid="false"
-                        class="pf-c-radio__input"
-                        data-ouia-component-id="OUIA-Generated-Radio-2"
-                        data-ouia-component-type="PF4/Radio"
-                        data-ouia-safe="true"
-                        disabled=""
-                        id="Extended support"
-                        name="Extended support"
-                        type="radio"
-                      />
-                      <label
-                        class="pf-c-radio__label pf-m-disabled"
-                        for="Extended support"
-                      >
-                        Extended support
-                      </label>
-                    </div>
+                        <div
+                          class="pf-c-form__group-label"
+                        >
+                          <label
+                            class="pf-c-form__label"
+                            for="activation-key-name"
+                          >
+                            <span
+                              class="pf-c-form__label-text"
+                            >
+                              Name
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="pf-c-form__label-required"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
+                           
+                        </div>
+                        <div
+                          class="pf-c-form__group-control"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="pf-c-form-control"
+                            data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                            data-ouia-component-type="PF4/TextInput"
+                            data-ouia-safe="true"
+                            id="activation-key-name"
+                            required=""
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            aria-live="polite"
+                            class="pf-c-form__helper-text"
+                            id="activation-key-name-helper"
+                          >
+                            Your activation key name must be unique and must contain only numbers, letters, underscores, and hyphens.
+                          </div>
+                        </div>
+                      </div>
+                    </form>
                   </div>
                 </div>
               </div>
@@ -997,21 +1535,23 @@ exports[`Create Activation Key Wizard renders page 2 correctly 1`] = `
                 class="pf-c-wizard__footer"
               >
                 <button
-                  aria-disabled="false"
-                  class="pf-c-button pf-m-primary"
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-primary pf-m-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-primary-2"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
+                  disabled=""
                   type="submit"
                 >
                   Next
                 </button>
                 <button
-                  aria-disabled="false"
-                  class="pf-c-button pf-m-secondary"
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-secondary pf-m-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-secondary-2"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
+                  disabled=""
                   type="button"
                 >
                   Back
@@ -1099,7 +1639,7 @@ exports[`Create Activation Key Wizard renders page 3 correctly 1`] = `
               <h2
                 aria-label="Create activation key"
                 class="pf-c-title pf-m-3xl pf-c-wizard__title"
-                data-ouia-component-id="OUIA-Generated-Title-6"
+                data-ouia-component-id="OUIA-Generated-Title-5"
                 data-ouia-component-type="PF4/Title"
                 data-ouia-safe="true"
                 id="pf-wizard-title-2"
@@ -1122,10 +1662,10 @@ exports[`Create Activation Key Wizard renders page 3 correctly 1`] = `
                   <span
                     class="pf-c-wizard__toggle-num"
                   >
-                    3
+                    1
                   </span>
                    
-                  System purpose
+                  Name
                 </span>
               </span>
               <span
@@ -1167,8 +1707,8 @@ exports[`Create Activation Key Wizard renders page 3 correctly 1`] = `
                       class="pf-c-wizard__nav-item"
                     >
                       <button
-                        aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-current="step"
+                        class="pf-c-wizard__nav-link pf-m-current"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-9"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
@@ -1181,10 +1721,12 @@ exports[`Create Activation Key Wizard renders page 3 correctly 1`] = `
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-10"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="1"
                       >
                         Workload
@@ -1194,11 +1736,13 @@ exports[`Create Activation Key Wizard renders page 3 correctly 1`] = `
                       class="pf-c-wizard__nav-item"
                     >
                       <button
-                        aria-current="step"
-                        class="pf-c-wizard__nav-link pf-m-current"
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-11"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="2"
                       >
                         System purpose
@@ -1209,10 +1753,12 @@ exports[`Create Activation Key Wizard renders page 3 correctly 1`] = `
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-12"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="3"
                       >
                         Review
@@ -1228,26 +1774,76 @@ exports[`Create Activation Key Wizard renders page 3 correctly 1`] = `
                   <div
                     class="pf-c-wizard__main-body"
                   >
-                    <div
-                      class="pf-l-bullseye"
+                    <h2
+                      class="pf-c-title pf-m-xl pf-u-mb-sm"
+                      data-ouia-component-id="OUIA-Generated-Title-6"
+                      data-ouia-component-type="PF4/Title"
+                      data-ouia-safe="true"
                     >
-                      <span
-                        aria-label="Contents"
-                        aria-valuetext="Loading..."
-                        class="pf-c-spinner pf-m-xl"
-                        role="progressbar"
+                      Name key
+                    </h2>
+                    <p
+                      class="pf-u-mb-xl"
+                      data-ouia-component-id="OUIA-Generated-Text-3"
+                      data-ouia-component-type="PF4/Text"
+                      data-ouia-safe="true"
+                      data-pf-content="true"
+                    >
+                      This name cannot be modified after the activation key is created.
+                    </p>
+                    <form
+                      class="pf-c-form"
+                      novalidate=""
+                    >
+                      <div
+                        class="pf-c-form__group"
                       >
-                        <span
-                          class="pf-c-spinner__clipper"
-                        />
-                        <span
-                          class="pf-c-spinner__lead-ball"
-                        />
-                        <span
-                          class="pf-c-spinner__tail-ball"
-                        />
-                      </span>
-                    </div>
+                        <div
+                          class="pf-c-form__group-label"
+                        >
+                          <label
+                            class="pf-c-form__label"
+                            for="activation-key-name"
+                          >
+                            <span
+                              class="pf-c-form__label-text"
+                            >
+                              Name
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="pf-c-form__label-required"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
+                           
+                        </div>
+                        <div
+                          class="pf-c-form__group-control"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="pf-c-form-control"
+                            data-ouia-component-id="OUIA-Generated-TextInputBase-3"
+                            data-ouia-component-type="PF4/TextInput"
+                            data-ouia-safe="true"
+                            id="activation-key-name"
+                            required=""
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            aria-live="polite"
+                            class="pf-c-form__helper-text"
+                            id="activation-key-name-helper"
+                          >
+                            Your activation key name must be unique and must contain only numbers, letters, underscores, and hyphens.
+                          </div>
+                        </div>
+                      </div>
+                    </form>
                   </div>
                 </div>
               </div>
@@ -1255,21 +1851,23 @@ exports[`Create Activation Key Wizard renders page 3 correctly 1`] = `
                 class="pf-c-wizard__footer"
               >
                 <button
-                  aria-disabled="false"
-                  class="pf-c-button pf-m-primary"
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-primary pf-m-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-primary-3"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
+                  disabled=""
                   type="submit"
                 >
                   Next
                 </button>
                 <button
-                  aria-disabled="false"
-                  class="pf-c-button pf-m-secondary"
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-secondary pf-m-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-secondary-3"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
+                  disabled=""
                   type="button"
                 >
                   Back
@@ -1357,7 +1955,7 @@ exports[`Create Activation Key Wizard renders page 4 correctly 1`] = `
               <h2
                 aria-label="Create activation key"
                 class="pf-c-title pf-m-3xl pf-c-wizard__title"
-                data-ouia-component-id="OUIA-Generated-Title-9"
+                data-ouia-component-id="OUIA-Generated-Title-7"
                 data-ouia-component-type="PF4/Title"
                 data-ouia-safe="true"
                 id="pf-wizard-title-3"
@@ -1380,10 +1978,10 @@ exports[`Create Activation Key Wizard renders page 4 correctly 1`] = `
                   <span
                     class="pf-c-wizard__toggle-num"
                   >
-                    4
+                    1
                   </span>
                    
-                  Review
+                  Name
                 </span>
               </span>
               <span
@@ -1425,8 +2023,8 @@ exports[`Create Activation Key Wizard renders page 4 correctly 1`] = `
                       class="pf-c-wizard__nav-item"
                     >
                       <button
-                        aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-current="step"
+                        class="pf-c-wizard__nav-link pf-m-current"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-13"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
@@ -1439,10 +2037,12 @@ exports[`Create Activation Key Wizard renders page 4 correctly 1`] = `
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-14"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="1"
                       >
                         Workload
@@ -1453,10 +2053,12 @@ exports[`Create Activation Key Wizard renders page 4 correctly 1`] = `
                     >
                       <button
                         aria-current="false"
-                        class="pf-c-wizard__nav-link"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-15"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="2"
                       >
                         System purpose
@@ -1466,11 +2068,13 @@ exports[`Create Activation Key Wizard renders page 4 correctly 1`] = `
                       class="pf-c-wizard__nav-item"
                     >
                       <button
-                        aria-current="step"
-                        class="pf-c-wizard__nav-link pf-m-current"
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
                         data-ouia-component-id="OUIA-Generated-WizardNavItem-16"
                         data-ouia-component-type="PF4/WizardNavItem"
                         data-ouia-safe="true"
+                        disabled=""
                         id="3"
                       >
                         Review
@@ -1488,138 +2092,74 @@ exports[`Create Activation Key Wizard renders page 4 correctly 1`] = `
                   >
                     <h2
                       class="pf-c-title pf-m-xl pf-u-mb-sm"
-                      data-ouia-component-id="OUIA-Generated-Title-12"
+                      data-ouia-component-id="OUIA-Generated-Title-8"
                       data-ouia-component-type="PF4/Title"
                       data-ouia-safe="true"
                     >
-                      Review
+                      Name key
                     </h2>
                     <p
                       class="pf-u-mb-xl"
-                      data-ouia-component-id="OUIA-Generated-Text-8"
+                      data-ouia-component-id="OUIA-Generated-Text-4"
                       data-ouia-component-type="PF4/Text"
                       data-ouia-safe="true"
                       data-pf-content="true"
                     >
-                      Review the following information and click 
-                      <b>
-                        Create
-                      </b>
-                       to create the activation key.
+                      This name cannot be modified after the activation key is created.
                     </p>
-                    <dl
-                      class="pf-c-description-list pf-m-horizontal"
-                      style="--pf-c-description-list--m-horizontal__term--width: 21ch;"
+                    <form
+                      class="pf-c-form"
+                      novalidate=""
                     >
                       <div
-                        class="pf-c-description-list__group"
+                        class="pf-c-form__group"
                       >
-                        <dt
-                          class="pf-c-description-list__term"
+                        <div
+                          class="pf-c-form__group-label"
                         >
-                          <span
-                            class="pf-c-description-list__text"
+                          <label
+                            class="pf-c-form__label"
+                            for="activation-key-name"
                           >
-                            Name
-                          </span>
-                        </dt>
-                        <dd
-                          class="pf-c-description-list__description"
+                            <span
+                              class="pf-c-form__label-text"
+                            >
+                              Name
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="pf-c-form__label-required"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
+                           
+                        </div>
+                        <div
+                          class="pf-c-form__group-control"
                         >
-                          <div
-                            class="pf-c-description-list__text"
+                          <input
+                            aria-invalid="false"
+                            class="pf-c-form-control"
+                            data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+                            data-ouia-component-type="PF4/TextInput"
+                            data-ouia-safe="true"
+                            id="activation-key-name"
+                            required=""
+                            type="text"
+                            value=""
                           />
-                        </dd>
-                      </div>
-                      <div
-                        class="pf-c-description-list__group"
-                      >
-                        <dt
-                          class="pf-c-description-list__term"
-                        >
-                          <span
-                            class="pf-c-description-list__text"
-                          >
-                            Workload
-                          </span>
-                        </dt>
-                        <dd
-                          class="pf-c-description-list__description"
-                        >
                           <div
-                            class="pf-c-description-list__text"
+                            aria-live="polite"
+                            class="pf-c-form__helper-text"
+                            id="activation-key-name-helper"
                           >
-                            Latest release
+                            Your activation key name must be unique and must contain only numbers, letters, underscores, and hyphens.
                           </div>
-                        </dd>
+                        </div>
                       </div>
-                      <div
-                        class="pf-c-description-list__group"
-                      >
-                        <dt
-                          class="pf-c-description-list__term"
-                        >
-                          <span
-                            class="pf-c-description-list__text"
-                          >
-                            Role
-                          </span>
-                        </dt>
-                        <dd
-                          class="pf-c-description-list__description"
-                        >
-                          <div
-                            class="pf-c-description-list__text"
-                          >
-                            Not defined
-                          </div>
-                        </dd>
-                      </div>
-                      <div
-                        class="pf-c-description-list__group"
-                      >
-                        <dt
-                          class="pf-c-description-list__term"
-                        >
-                          <span
-                            class="pf-c-description-list__text"
-                          >
-                            Service level agreement (SLA)
-                          </span>
-                        </dt>
-                        <dd
-                          class="pf-c-description-list__description"
-                        >
-                          <div
-                            class="pf-c-description-list__text"
-                          >
-                            Not defined
-                          </div>
-                        </dd>
-                      </div>
-                      <div
-                        class="pf-c-description-list__group"
-                      >
-                        <dt
-                          class="pf-c-description-list__term"
-                        >
-                          <span
-                            class="pf-c-description-list__text"
-                          >
-                            Usage
-                          </span>
-                        </dt>
-                        <dd
-                          class="pf-c-description-list__description"
-                        >
-                          <div
-                            class="pf-c-description-list__text"
-                          >
-                            Not defined
-                          </div>
-                        </dd>
-                      </div>
-                    </dl>
+                    </form>
                   </div>
                 </div>
               </div>
@@ -1627,21 +2167,23 @@ exports[`Create Activation Key Wizard renders page 4 correctly 1`] = `
                 class="pf-c-wizard__footer"
               >
                 <button
-                  aria-disabled="false"
-                  class="pf-c-button pf-m-primary"
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-primary pf-m-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-primary-4"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
+                  disabled=""
                   type="submit"
                 >
-                  Create
+                  Next
                 </button>
                 <button
-                  aria-disabled="false"
-                  class="pf-c-button pf-m-secondary"
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-secondary pf-m-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-secondary-4"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
+                  disabled=""
                   type="button"
                 >
                   Back
@@ -1653,6 +2195,322 @@ exports[`Create Activation Key Wizard renders page 4 correctly 1`] = `
                     aria-disabled="false"
                     class="pf-c-button pf-m-link"
                     data-ouia-component-id="OUIA-Generated-Button-link-4"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Create Activation Key Wizard renders page 5 correctly 1`] = `
+<body
+  class="pf-c-backdrop__open"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div>
+    <div
+      class="pf-c-backdrop"
+    >
+      <div
+        class="pf-l-bullseye"
+      >
+        <div
+          aria-label="Create activation key wizard"
+          aria-labelledby="pf-modal-part-4"
+          aria-modal="true"
+          class="pf-c-modal-box pf-m-lg"
+          data-ouia-component-id="OUIA-Generated-Modal-large-5"
+          data-ouia-component-type="PF4/ModalContent"
+          data-ouia-safe="true"
+          id="pf-modal-part-4"
+          role="dialog"
+        >
+          
+          <div
+            class="pf-c-wizard"
+            style="height: 400px;"
+          >
+            <div
+              class="pf-c-wizard__header"
+            >
+              <button
+                aria-disabled="false"
+                aria-label="Close"
+                class="pf-c-button pf-m-plain pf-c-wizard__close"
+                data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </button>
+              <h2
+                aria-label="Create activation key"
+                class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                data-ouia-component-id="OUIA-Generated-Title-9"
+                data-ouia-component-type="PF4/Title"
+                data-ouia-safe="true"
+                id="pf-wizard-title-4"
+              >
+                Create activation key
+              </h2>
+              
+            </div>
+            <button
+              aria-expanded="false"
+              aria-label="Wizard Toggle"
+              class="pf-c-wizard__toggle"
+            >
+              <span
+                class="pf-c-wizard__toggle-list"
+              >
+                <span
+                  class="pf-c-wizard__toggle-list-item"
+                >
+                  <span
+                    class="pf-c-wizard__toggle-num"
+                  >
+                    1
+                  </span>
+                   
+                  Name
+                </span>
+              </span>
+              <span
+                class="pf-c-wizard__toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <div
+              class="pf-c-wizard__outer-wrap"
+            >
+              <div
+                class="pf-c-wizard__inner-wrap"
+              >
+                <nav
+                  aria-label="Create activation key steps"
+                  aria-labelledby="pf-wizard-title-4"
+                  class="pf-c-wizard__nav"
+                  data-ouia-component-id="OUIA-Generated-WizardNav-5"
+                  data-ouia-component-type="PF4/WizardNav"
+                  data-ouia-safe="true"
+                >
+                  <ol
+                    class="pf-c-wizard__nav-list"
+                  >
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="step"
+                        class="pf-c-wizard__nav-link pf-m-current"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-17"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                      >
+                        Name
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-18"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                        disabled=""
+                        id="1"
+                      >
+                        Workload
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-19"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                        disabled=""
+                        id="2"
+                      >
+                        System purpose
+                      </button>
+                    </li>
+                    <li
+                      class="pf-c-wizard__nav-item"
+                    >
+                      <button
+                        aria-current="false"
+                        aria-disabled="true"
+                        class="pf-c-wizard__nav-link pf-m-disabled"
+                        data-ouia-component-id="OUIA-Generated-WizardNavItem-20"
+                        data-ouia-component-type="PF4/WizardNavItem"
+                        data-ouia-safe="true"
+                        disabled=""
+                        id="3"
+                      >
+                        Review
+                      </button>
+                    </li>
+                  </ol>
+                </nav>
+                <div
+                  aria-label="Create activation key content"
+                  aria-labelledby="pf-wizard-title-4"
+                  class="pf-c-wizard__main"
+                >
+                  <div
+                    class="pf-c-wizard__main-body"
+                  >
+                    <h2
+                      class="pf-c-title pf-m-xl pf-u-mb-sm"
+                      data-ouia-component-id="OUIA-Generated-Title-10"
+                      data-ouia-component-type="PF4/Title"
+                      data-ouia-safe="true"
+                    >
+                      Name key
+                    </h2>
+                    <p
+                      class="pf-u-mb-xl"
+                      data-ouia-component-id="OUIA-Generated-Text-5"
+                      data-ouia-component-type="PF4/Text"
+                      data-ouia-safe="true"
+                      data-pf-content="true"
+                    >
+                      This name cannot be modified after the activation key is created.
+                    </p>
+                    <form
+                      class="pf-c-form"
+                      novalidate=""
+                    >
+                      <div
+                        class="pf-c-form__group"
+                      >
+                        <div
+                          class="pf-c-form__group-label"
+                        >
+                          <label
+                            class="pf-c-form__label"
+                            for="activation-key-name"
+                          >
+                            <span
+                              class="pf-c-form__label-text"
+                            >
+                              Name
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="pf-c-form__label-required"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
+                           
+                        </div>
+                        <div
+                          class="pf-c-form__group-control"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="pf-c-form-control"
+                            data-ouia-component-id="OUIA-Generated-TextInputBase-5"
+                            data-ouia-component-type="PF4/TextInput"
+                            data-ouia-safe="true"
+                            id="activation-key-name"
+                            required=""
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            aria-live="polite"
+                            class="pf-c-form__helper-text"
+                            id="activation-key-name-helper"
+                          >
+                            Your activation key name must be unique and must contain only numbers, letters, underscores, and hyphens.
+                          </div>
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </div>
+              <footer
+                class="pf-c-wizard__footer"
+              >
+                <button
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-primary pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-primary-5"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  type="submit"
+                >
+                  Next
+                </button>
+                <button
+                  aria-disabled="true"
+                  class="pf-c-button pf-m-secondary pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-secondary-5"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  type="button"
+                >
+                  Back
+                </button>
+                <div
+                  class="pf-c-wizard__footer-cancel"
+                >
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-5"
                     data-ouia-component-type="PF4/Button"
                     data-ouia-safe="true"
                     type="button"

--- a/src/Components/Pages/ReviewPage.js
+++ b/src/Components/Pages/ReviewPage.js
@@ -7,11 +7,21 @@ import {
   DescriptionListTerm,
   DescriptionListGroup,
   DescriptionListDescription,
+  TextContent,
 } from '@patternfly/react-core';
 import Loading from '../LoadingState/Loading';
 import PropTypes from 'prop-types';
 
-const ReviewPage = ({ name, workload, role, sla, usage, isLoading }) => {
+const ReviewPage = ({
+  name,
+  workload,
+  role,
+  sla,
+  usage,
+  isLoading,
+  extendedReleaseProduct,
+  extendedReleaseVersion,
+}) => {
   return isLoading ? (
     <Loading />
   ) : (
@@ -35,7 +45,17 @@ const ReviewPage = ({ name, workload, role, sla, usage, isLoading }) => {
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>Workload</DescriptionListTerm>
-          <DescriptionListDescription>{workload}</DescriptionListDescription>
+          <DescriptionListDescription>
+            <TextContent>
+              <Text component="p">{workload}</Text>
+              {workload.includes('Extended') && (
+                <>
+                  <Text component="p">{extendedReleaseProduct}</Text>
+                  <Text component="p">{extendedReleaseVersion}</Text>
+                </>
+              )}
+            </TextContent>
+          </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>Role</DescriptionListTerm>
@@ -69,6 +89,8 @@ ReviewPage.propTypes = {
   sla: PropTypes.string.isRequired,
   usage: PropTypes.string.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  extendedReleaseProduct: PropTypes.string.isRequired,
+  extendedReleaseVersion: PropTypes.string.isRequired,
 };
 
 export default ReviewPage;

--- a/src/Components/Pages/SetNamePage.js
+++ b/src/Components/Pages/SetNamePage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Title,
@@ -9,7 +9,10 @@ import {
   Form,
 } from '@patternfly/react-core';
 
-const SetNamePage = ({ name, setName }) => {
+const SetNamePage = ({ name, setName, nameIsValid }) => {
+  const [enableValidationFeedback, setEnableValidationFeedback] =
+    useState(false);
+
   const helperText =
     'Your activation key name must be unique and must contain only numbers, letters, underscores, and hyphens.';
 
@@ -31,6 +34,10 @@ const SetNamePage = ({ name, setName }) => {
           isRequired
           helperText={helperText}
           fieldId="activation-key-name"
+          validated={
+            nameIsValid || !enableValidationFeedback ? 'default' : 'error'
+          }
+          helperTextInvalid={`Name requirements have not been met. ${helperText}`}
         >
           <TextInput
             id="activation-key-name"
@@ -38,6 +45,10 @@ const SetNamePage = ({ name, setName }) => {
             type="text"
             value={name}
             onChange={setName}
+            validated={
+              nameIsValid || !enableValidationFeedback ? 'default' : 'error'
+            }
+            onBlur={() => setEnableValidationFeedback(true)}
           />
         </FormGroup>
       </Form>
@@ -48,6 +59,7 @@ const SetNamePage = ({ name, setName }) => {
 SetNamePage.propTypes = {
   name: PropTypes.string.isRequired,
   setName: PropTypes.func.isRequired,
+  nameIsValid: PropTypes.bool.isRequired,
 };
 
 export default SetNamePage;

--- a/src/Components/Pages/SetWorkLoadPage.js
+++ b/src/Components/Pages/SetWorkLoadPage.js
@@ -1,8 +1,56 @@
-import React from 'react';
-import { Title, Text, TextVariants, Radio } from '@patternfly/react-core';
+import React, { useEffect } from 'react';
+import {
+  Title,
+  Text,
+  TextVariants,
+  Radio,
+  Spinner,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+} from '@patternfly/react-core';
 import PropTypes from 'prop-types';
+import useEusVersions from '../../hooks/useEusVersions';
 
-const SetWorkloadPage = ({ workloadOptions, workload, setWorkload }) => {
+const SetWorkloadPage = ({
+  workloadOptions,
+  workload,
+  setWorkload,
+  extendedReleaseProduct,
+  setExtendedReleaseProduct,
+  extendedReleaseVersion,
+  setExtendedReleaseVersion,
+  setExtendedReleaseRepositories,
+}) => {
+  const { isLoading, error, data } = useEusVersions();
+
+  useEffect(() => {
+    if (workload.includes('Extended') && data) {
+      setExtendedReleaseProduct(extendedReleaseProduct || data[0].name);
+      setExtendedReleaseVersion(
+        extendedReleaseVersion || data[0].configurations[0].version
+      );
+    } else {
+      setExtendedReleaseProduct('');
+      setExtendedReleaseVersion('');
+    }
+  }, [data, workload]);
+
+  useEffect(() => {
+    if (data && workload.includes('Extended')) {
+      setExtendedReleaseRepositories(
+        data
+          .find((product) => extendedReleaseProduct == product.name)
+          .configurations.find(
+            (configuration) => extendedReleaseVersion == configuration.version
+          ).repositories
+      );
+    } else {
+      setExtendedReleaseRepositories([]);
+    }
+  }, [data, extendedReleaseProduct, extendedReleaseVersion]);
+
   return (
     <>
       <Title headingLevel="h2" className="pf-u-mb-sm">
@@ -13,20 +61,65 @@ const SetWorkloadPage = ({ workloadOptions, workload, setWorkload }) => {
         repositories to the activation key. Repositories can be edited on the
         activation key detail page.{' '}
       </Text>
-      {workloadOptions.map((wl) => {
-        return (
-          <Radio
-            label={wl}
-            onChange={() => setWorkload(wl)}
-            isChecked={wl == workload}
-            className="pf-u-mb-md"
-            name={wl}
-            id={wl}
-            isDisabled={wl == 'Extended support'}
-            key={wl}
-          />
-        );
-      })}
+      {!isLoading ? (
+        workloadOptions.map((wl) => {
+          return (
+            <Radio
+              label={wl}
+              onChange={() => setWorkload(wl)}
+              isChecked={wl == workload}
+              className="pf-u-mb-md"
+              name={wl}
+              id={wl}
+              isDisabled={wl == 'Extended support' && error == 400}
+              key={wl}
+            />
+          );
+        })
+      ) : (
+        <Spinner />
+      )}
+
+      {workload === 'Extended support' && (
+        <Form>
+          <FormGroup label="Product">
+            <FormSelect
+              onChange={(v) => setExtendedReleaseProduct(v)}
+              value={extendedReleaseProduct}
+              id="product"
+            >
+              {data.map((product, i) => {
+                return (
+                  <FormSelectOption
+                    key={i}
+                    value={product.name}
+                    label={product.name}
+                  />
+                );
+              })}
+            </FormSelect>
+          </FormGroup>
+          <FormGroup label="Version">
+            <FormSelect
+              onChange={(v) => setExtendedReleaseVersion(v)}
+              value={extendedReleaseVersion}
+              id="version"
+            >
+              {data
+                .find((product) => product.name == extendedReleaseProduct)
+                ?.configurations.map((configuration, i) => {
+                  return (
+                    <FormSelectOption
+                      key={i}
+                      value={configuration.version}
+                      label={configuration.version}
+                    />
+                  );
+                })}
+            </FormSelect>
+          </FormGroup>
+        </Form>
+      )}
     </>
   );
 };
@@ -35,6 +128,11 @@ SetWorkloadPage.propTypes = {
   workloadOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
   workload: PropTypes.string.isRequired,
   setWorkload: PropTypes.func.isRequired,
+  extendedReleaseProduct: PropTypes.string.isRequired,
+  setExtendedReleaseProduct: PropTypes.func.isRequired,
+  extendedReleaseVersion: PropTypes.string.isRequired,
+  setExtendedReleaseVersion: PropTypes.func.isRequired,
+  setExtendedReleaseRepositories: PropTypes.func.isRequired,
 };
 
 export default SetWorkloadPage;

--- a/src/Components/Pages/SuccessPage.js
+++ b/src/Components/Pages/SuccessPage.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateSecondaryActions,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+import { useHistory } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+const SuccessPage = ({ isLoading, name, onClose }) => {
+  const history = useHistory();
+
+  const content = isLoading ? (
+    <Spinner />
+  ) : (
+    <EmptyState>
+      <EmptyStateIcon color="green" icon={CheckCircleIcon} />
+      <Title headingLevel="h4">Activation key created</Title>
+      <EmptyStateBody>
+        <b>{name}</b> is now available for use. Click <b>View activation key</b>{' '}
+        to edit settings or add repositories.
+      </EmptyStateBody>
+      <Button
+        variant="primary"
+        onClick={() => history.push(`/activation-keys/${name}`)}
+      >
+        View activation key
+      </Button>
+      <EmptyStateSecondaryActions>
+        <Button variant="link" onClick={onClose}>
+          Close
+        </Button>
+      </EmptyStateSecondaryActions>
+    </EmptyState>
+  );
+
+  return <Bullseye>{content}</Bullseye>;
+};
+
+SuccessPage.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  name: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default SuccessPage;

--- a/src/hooks/useCreateActivationKey.js
+++ b/src/hooks/useCreateActivationKey.js
@@ -2,19 +2,28 @@ import { useMutation } from 'react-query';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const activationKeyMutation = (token) => async (data) => {
-  const { name, role, serviceLevel, usage } = data;
+  const { name, role, serviceLevel, usage, additionalRepositories } = data;
+
+  const body = {
+    name: name,
+    role: role,
+    serviceLevel: serviceLevel,
+    usage: usage,
+  };
+
+  if (additionalRepositories) {
+    body.additionalRepositories = additionalRepositories.map(
+      (repositoryLabel) => ({ repositoryLabel })
+    );
+  }
+
   const response = await fetch('/api/rhsm/v2/activation_keys', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${await token}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      name: name,
-      role: role,
-      serviceLevel: serviceLevel,
-      usage: usage,
-    }),
+    body: JSON.stringify(body),
   });
   if (!response.ok) {
     throw new Error(

--- a/src/hooks/useEusVersions.js
+++ b/src/hooks/useEusVersions.js
@@ -1,0 +1,36 @@
+import { useQuery } from 'react-query';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+
+const fetchEusVersions = (token) => async () => {
+  const response = await fetch(
+    '/api/rhsm/v2/products/RHEL/extended-update-support-products',
+    {
+      headers: { Authorization: `Bearer ${await token}` },
+    }
+  );
+
+  if (!response.ok) {
+    return Promise.reject(response.status);
+  }
+
+  const eusVersionsData = await response.json();
+
+  return eusVersionsData.body;
+};
+
+const useEusVersions = () => {
+  const chrome = useChrome();
+
+  return useQuery({
+    queryKey: 'eus_versions',
+    queryFn: () => fetchEusVersions(chrome?.auth?.getToken())(),
+    retry: (failureCount, error) => {
+      if (failureCount < 3 && error != '400') {
+        return true;
+      }
+      return false;
+    },
+  });
+};
+
+export { useEusVersions as default };


### PR DESCRIPTION
# Description

This adds workload selection to automatically add applicable additional repositories for RHEL EUS versions. These are set by name and version, which maps to an array of repos all provided by the rhsm-api endpoint `v2/products/RHEL/extended-update-support-versions` endpoint.

It also adds alphanumeric, -, and _ validation for the name of an activation key.

It also adds a success page with a link to the key, and the ability to close and continue looking at the list of keys.

Associated Jira ticket: TEAMNADO-5120
