### PR TITLE
DO NOT MERGE TEAMNADO-5441: Unset release version

### DIFF
--- a/src/Components/Forms/EditReleaseVersionForm.js
+++ b/src/Components/Forms/EditReleaseVersionForm.js
@@ -29,16 +29,13 @@ export const EditReleaseVersionForm = ({
     <FormSelectOption value={version} label={version} key={i} />
   ));
 
-  if (!activationKey.releaseVersion) {
-    options.push(
-      <FormSelectOption
-        value=""
-        label="Not defined"
-        key={releaseVersions?.length}
-        isDisabled
-      />
-    );
-  }
+  options.push(
+    <FormSelectOption
+      value=""
+      label="Not defined"
+      key={releaseVersions?.length}
+    />
+  );
 
   const submitForm = () => {
     mutate(


### PR DESCRIPTION
This allows us to unset the release version for an activation key. It is dependent on RHSM-API adding support for it, so don't merge this until that is ready. It can be reviewed now though.