### PR TITLE
TEAMNADO-5654: Remove edit activation key from dialog, chain to trash icon

### DIFF
--- a/src/Components/ActivationKeys/DeleteActivationKeyButton.js
+++ b/src/Components/ActivationKeys/DeleteActivationKeyButton.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { WriteOnlyButton } from '../WriteOnlyButton';
+import { TrashIcon } from '@patternfly/react-icons';
+
+const DeleteActivationKeyButton = ({ onClick }) => {
+  return (
+    <WriteOnlyButton
+      variant="plain"
+      onClick={onClick}
+      disabledTooltip="For editing access, contact your administrator."
+      enabledTooltip="Delete"
+    >
+      <TrashIcon />
+    </WriteOnlyButton>
+  );
+};
+
+DeleteActivationKeyButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+
+export default DeleteActivationKeyButton;

--- a/src/Components/ActivationKeysTable/ActivationKeysTable.js
+++ b/src/Components/ActivationKeysTable/ActivationKeysTable.js
@@ -16,6 +16,7 @@ import propTypes from 'prop-types';
 import { useQueryClient } from 'react-query';
 import { KebabToggle } from '@patternfly/react-core';
 import useFeatureFlag from '../../hooks/useFeatureFlag';
+import DeleteActivationKeyButton from '../ActivationKeys/DeleteActivationKeyButton';
 
 const CustomActionsToggle = (props) => (
   <KebabToggle
@@ -75,12 +76,19 @@ const ActivationKeysTable = (props) => {
                   {datum.serviceLevel}
                 </Td>
                 <Td dataLabel={columnNames.usage}>{datum.usage}</Td>
-                <Td isActionCell>
-                  <ActionsColumn
-                    items={rowActions}
-                    isDisabled={isActionsDisabled()}
-                    actionsToggle={CustomActionsToggle}
-                  />
+                <Td isActionCell={!keyDetailsIsEnabled}>
+                  {!keyDetailsIsEnabled && (
+                    <ActionsColumn
+                      items={rowActions}
+                      isDisabled={isActionsDisabled()}
+                      actionsToggle={CustomActionsToggle}
+                    />
+                  )}
+                  {keyDetailsIsEnabled && (
+                    <DeleteActivationKeyButton
+                      onClick={rowActions[1].onClick}
+                    />
+                  )}
                 </Td>
               </Tr>
             );


### PR DESCRIPTION
This removes the edit option from the activation key table, and replaces the three dot menu with a trash can icon to delete.

All of these changes are gated behind the feature flag `sed-frontend.activationKeysDetailsPage`.