### PR TITLE
chore(RHINENG-2660): Add ability to filter by CentOS systems

### DIFF
--- a/src/Components/ConnectLog/SystemsTable.js
+++ b/src/Components/ConnectLog/SystemsTable.js
@@ -27,6 +27,7 @@ const SystemsTable = () => {
           ...mergeWithEntities(),
         });
       }}
+      showCentosVersions
     />
   );
 };


### PR DESCRIPTION
To test:

Go to stage
/insights/connector/
Click "View log"
Click Systems tab
Click filter and select Operating systems
Click the dropdown

Notice that the dropdown options do not include CentOS system versions

This PR exposes CentOS versions in the inventory table OS filter.