### PR TITLE
fix(RHINENG-5267): Fix broken View Playbook button

### DIFF
--- a/src/Components/ConfirmChangesModal/index.js
+++ b/src/Components/ConfirmChangesModal/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useConfigApi } from '../../api';
+import { useGetPlaybookPreview } from '../../api';
 import { Button, Modal, Text, TextContent } from '@patternfly/react-core';
 import { pluralize, downloadFile } from '../../utils/helpers';
 
@@ -11,7 +11,7 @@ const ConfirmChangesModal = ({
   systemsCount,
   data,
 }) => {
-  const configApi = useConfigApi();
+  const playbook = useGetPlaybookPreview(data);
 
   return (
     <Modal
@@ -55,14 +55,7 @@ const ConfirmChangesModal = ({
       <Button
         variant="link"
         onClick={() => {
-          (async () => {
-            const playbook = await configApi.getPlaybookPreview({
-              compliance: data.compliance,
-              insights: data.insights,
-              remediations: data.remediations,
-            });
-            downloadFile(playbook);
-          })();
+          downloadFile(playbook);
         }}
         style={{ paddingLeft: 0 }}
       >

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,11 +1,58 @@
 export const CONNECTOR_API_BASE = '/api/config-manager/v2';
+export const V1_API_BASE = '/api/config-manager/v1';
 
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import { DefaultApi } from '@redhat-cloud-services/config-manager-client';
+import { useEffect, useRef, useState } from 'react';
 
 export * from './inventory';
 
 export const useConfigApi = () => {
   const axiosInstance = useAxiosWithPlatformInterceptors();
   return new DefaultApi(undefined, CONNECTOR_API_BASE, axiosInstance);
+};
+
+const dataTransformer = (data) => {
+  if ('compliance' in data && 'remediations' in data && 'active' in data) {
+    let mapped = {};
+    Object.keys(data).forEach((key) => {
+      data[key] === true
+        ? (mapped[key] = 'enabled')
+        : (mapped[key] = 'disabled');
+    });
+    return mapped;
+  } else {
+    return false;
+  }
+};
+
+export const useGetPlaybookPreview = (data) => {
+  const axios = useAxiosWithPlatformInterceptors();
+  const [preview, setPreview] = useState();
+  const mounted = useRef(false);
+  useEffect(() => {
+    mounted.current = true;
+    const fetchData = async () => {
+      try {
+        const previewData = dataTransformer(data);
+        const playbookPreview =
+          previewData &&
+          (await axios.post(`${V1_API_BASE}/states/preview`, {
+            compliance_openscap: previewData.compliance,
+            insights: previewData.active,
+            remediations: previewData.remediations,
+          }));
+        mounted.current && setPreview(playbookPreview);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchData();
+    return () => {
+      mounted.current = false;
+    };
+  }, [data]);
+
+  return preview;
 };


### PR DESCRIPTION
# Description

[Associated Jira ticket: # (issue)](https://issues.redhat.com/browse/RHINENG-5267) 
The JS Client we got the api end point from was removed some time ago. This updates the app so that it makes the appropriate api to download the file thats supposed to be downloaded when clicked 'View Playbook'

# How to test the PR

Simply navigate to RHC manager, toggle an option, and click "Save changes." The pop-up will contain the 'View Playbook' button. Click that thang and see that youre able to download

# Before the change
Doesnt download anything. console logs that getPlaybookPreview doesnt exist, because it was removed from the JS client.

# After the change
Api req is made and you download a file.



# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
