### PR TITLE
fix(RHINENG-7689): change permission wording

### DIFF
--- a/src/Components/Services/permissionsConfig.js
+++ b/src/Components/Services/permissionsConfig.js
@@ -1,13 +1,17 @@
 export const permissions = [
   {
     id: 'remediations',
-    name: 'Allow Insights users to use “Remediations” to send Ansible Playbooks to fix issues on your systems',
+    name: 'Allow permitted Insights users to execute remediation playbooks on rhc-connected systems',
     description:
-      'Users can create Ansible Playbooks using the “Remediate” function in Insights and then execute these playbooks on systems in inventory. Playbooks are sent to systems to fix issues using the Cloud Connector technology.',
+      'Users with Remediations administrator access can execute Ansible Playbooks on rhc-connected systems in inventory. NOTE: This setting does not enable remote playbook remediations on Satellite-managed content hosts. ',
     links: [
       {
-        name: 'About Cloud Connector',
+        name: 'About Remote host configuration and management',
         link: 'https://access.redhat.com/documentation/en-us/red_hat_insights/1-latest/html/remote_host_configuration_and_management/index',
+      },
+      {
+        name: 'About Enabling remote playbook remediations for Satellite-managed content hosts',
+        link: 'https://access.redhat.com/documentation/en-us/red_hat_insights/1-latest/html/red_hat_insights_remediations_guide/index',
       },
     ],
   },


### PR DESCRIPTION
# Description

Change wording in RHC Manager Remediation permission

Associated Jira ticket: [RHINENG-7689](https://issues.redhat.com/browse/RHINENG-7689)

# How to test the PR

1. Go to RHC Manager
2. Observe changed wording in Remediation permission

# Before the change

![image](https://github.com/user-attachments/assets/d9b866da-05a0-48ab-885b-f2be3a68558d)

# After the change

![image](https://github.com/user-attachments/assets/bb63f6d3-c255-4ee1-aa2e-7964d9994aaa)


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
