### PR TITLE
RHINENG-17056 remove deprecated RHC-Manager permissions

### DIFF
--- a/src/Components/Services/Services.js
+++ b/src/Components/Services/Services.js
@@ -57,9 +57,6 @@ const Services = ({
     '',
     [
       'config-manager:activation_keys:*',
-      'config-manager:state:read',
-      'config-manager:state:write',
-      'config-manager:state-changes:read',
       'inventory:hosts:read',
       'inventory:hosts:write',
       'playbook-dispatcher:run:read',


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-17056](https://issues.redhat.com/browse/RHINENG-17056)

`state` and `state-changes` resources have been deprecated and are no longer associated with any endpoint. 

# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
