### PR TITLE
feat: Use remediations: true instead of insights: true when saving state

### DIFF
--- a/src/Components/ConfirmChangesModal/index.js
+++ b/src/Components/ConfirmChangesModal/index.js
@@ -40,7 +40,7 @@ const ConfirmChangesModal = ({
     >
       <TextContent>
         <Text component="p">
-          Your changes applies to{' '}
+          Your change applies to{' '}
           <b>
             {systemsCount} connected {pluralize(systemsCount, 'system')}
           </b>

--- a/src/Components/shared/ConditionalTooltip.js
+++ b/src/Components/shared/ConditionalTooltip.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
+
+const ConditionalTooltip = ({ isVisible, children, ...props }) =>
+  isVisible ? <Tooltip {...props}>{children}</Tooltip> : children;
+
+ConditionalTooltip.propTypes = {
+  isVisible: propTypes.bool,
+  children: propTypes.node,
+};
+
+export default ConditionalTooltip;

--- a/src/Routes/Dashboard/index.js
+++ b/src/Routes/Dashboard/index.js
@@ -1,8 +1,6 @@
 import {
-  Bullseye,
   Flex,
   FlexItem,
-  Spinner,
   Split,
   SplitItem,
   Page,
@@ -41,8 +39,6 @@ const SamplePage = () => {
   );
   const { getRegistry } = useContext(RegistryContext);
   const [confirmChangesOpen, setConfirmChangesOpen] = useState(false);
-  const [madeChanges, setMadeChanges] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
   const dataRef = useRef();
   const dispatch = useDispatch();
   const { fetchConnectedHosts, fetchCurrState, saveCurrState } = useActions();
@@ -51,11 +47,9 @@ const SamplePage = () => {
   const activeStateLoaded = useSelector(
     ({ activeStateReducer }) => activeStateReducer?.loaded
   );
-  const { compliance, remediations, active, profileId } = useSelector(
+  const { remediations, profileId } = useSelector(
     ({ activeStateReducer }) => ({
-      compliance: activeStateReducer?.values?.compliance,
       remediations: activeStateReducer?.values?.remediations,
-      active: activeStateReducer?.values?.active,
       profileId: activeStateReducer?.values?.id,
     }),
     shallowEqual
@@ -122,28 +116,14 @@ const SamplePage = () => {
       </PageHeader>
       <Page>
         <div className="dashboard__content">
-          {activeStateLoaded ||
-          (compliance !== undefined && remediations !== undefined) ? (
-            <Services
-              madeChanges={madeChanges}
-              setConfirmChangesOpen={setConfirmChangesOpen}
-              setMadeChanges={setMadeChanges}
-              setIsEditing={setIsEditing}
-              isEditing={isEditing}
-              defaults={{
-                compliance,
-                remediations,
-                active,
-              }}
-              onChange={(data) => {
-                dataRef.current = data;
-              }}
-            />
-          ) : (
-            <Bullseye>
-              <Spinner className="pf-v5-u-p-lg" size="xl" />
-            </Bullseye>
-          )}
+          <Services
+            setConfirmChangesOpen={setConfirmChangesOpen}
+            defaults={{ remediations }}
+            onChange={(data) => {
+              dataRef.current = data;
+            }}
+            isLoading={!activeStateLoaded}
+          />
         </div>
       </Page>
       <ConfirmChangesModal
@@ -164,8 +144,6 @@ const SamplePage = () => {
                   'Your service enablement changes were applied to connected systems',
               })
             );
-            setMadeChanges(false);
-            setIsEditing(false);
           })();
         }}
         profileId={profileId}

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -12,13 +12,13 @@ const fetchCurrState = (api) => () => ({
 
 const saveCurrState =
   (api) =>
-  ({ compliance, remediations, active }) => ({
+  ({ remediations }) => ({
     type: SET_CURR_STATE,
     payload: api.createProfile({
-      compliance,
+      active: true,
+      compliance: true,
       insights: true,
       remediations,
-      active,
     }),
   });
 

--- a/src/store/connectedSystems.js
+++ b/src/store/connectedSystems.js
@@ -15,7 +15,7 @@ const connectedSystemsFulfilled = (state, { payload }) => ({
   ...state,
   loaded: true,
   hosts: payload?.results || [],
-  total: payload?.count || 0,
+  total: payload?.total || 0,
   page: payload?.page || 0,
   perPage: payload?.per_page || 0,
 });

--- a/src/store/connectedSystems.test.js
+++ b/src/store/connectedSystems.test.js
@@ -41,7 +41,7 @@ describe('connectedSystems', () => {
         type: `${GET_CONNECTED_HOSTS}_FULFILLED`,
         payload: {
           results: ['one'],
-          count: 10,
+          total: 10,
           page: 1,
           per_page: 10,
         },


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/RHINENG-13152

- Fix grammar in confirm modal -- "Your changes applies to..." -->  "Your change applies to..."
- Fix all system count in confirm modal being limited to 50 (it was using count within the page not total).
- Set values to removed toggles to `true` in `createProfile` API call -- these toggles will be removed on the backend.