### PR TITLE
feat(RHINENG-15924): Update javascript client to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@patternfly/react-core": "^5.3.4",
         "@patternfly/react-icons": "^5.0.0",
         "@patternfly/react-table": "^5.0.0",
-        "@redhat-cloud-services/config-manager-client": "^1.5.0",
+        "@redhat-cloud-services/config-manager-client": "^4.0.1",
         "@redhat-cloud-services/frontend-components": "^4.0.1",
         "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
@@ -4671,21 +4671,14 @@
       "dev": true
     },
     "node_modules/@redhat-cloud-services/config-manager-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/config-manager-client/-/config-manager-client-1.5.0.tgz",
-      "integrity": "sha512-SVi49iBYI8k0qnvEcXpFhpomwwM5aERqJuL+XvxBTIhCoZTb8jf8ZXH8y26GbuUM/Iu3G4bHSWslL98QIB45mw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/config-manager-client/-/config-manager-client-4.0.1.tgz",
+      "integrity": "sha512-bHWbfu6dP5f/OkJ3RW6ZHqx/McMSvQZM9JiO0aE9MGwDYnFxxaW2UoUQz27bkHqFfiuzOtkhYIC8/u6XOsTCBQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^0.27.2",
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
+        "axios": "^1.7.2",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@redhat-cloud-services/config-manager-client/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@redhat-cloud-services/eslint-config-redhat-cloud-services": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@patternfly/react-core": "^5.3.4",
     "@patternfly/react-icons": "^5.0.0",
     "@patternfly/react-table": "^5.0.0",
-    "@redhat-cloud-services/config-manager-client": "^1.5.0",
+    "@redhat-cloud-services/config-manager-client": "^4.0.1",
     "@redhat-cloud-services/frontend-components": "^4.0.1",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,14 +1,14 @@
 export const CONNECTOR_API_BASE = '/api/config-manager/v2';
 
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
-import { DefaultApi } from '@redhat-cloud-services/config-manager-client';
+import { ConfigManagerClient } from '@redhat-cloud-services/config-manager-client/api';
 import { useEffect, useRef, useState } from 'react';
 
 export * from './inventory';
 
 export const useConfigApi = () => {
   const axiosInstance = useAxiosWithPlatformInterceptors();
-  return new DefaultApi(undefined, CONNECTOR_API_BASE, axiosInstance);
+  return ConfigManagerClient(CONNECTOR_API_BASE, axiosInstance);
 };
 
 export const useGetPlaybookPreview = (profileId) => {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -7,19 +7,21 @@ import {
 
 const fetchCurrState = (api) => () => ({
   type: GET_CURR_STATE,
-  payload: api.getProfile('current'),
+  payload: api.getProfile('current').then((response) => response.data),
 });
 
 const saveCurrState =
   (api) =>
   ({ remediations }) => ({
     type: SET_CURR_STATE,
-    payload: api.createProfile({
-      active: true,
-      compliance: true,
-      insights: true,
-      remediations,
-    }),
+    payload: api
+      .createProfile({
+        active: true,
+        compliance: true,
+        insights: true,
+        remediations,
+      })
+      .then((response) => response.data),
   });
 
 const fetchConnectedHosts = (api) => () => ({


### PR DESCRIPTION
# Description

Associated Jira ticket: # RHINENG-15924

Update of javascript client to the latest version.
DefaultApi class has been changed to ConfigManagerClient function.

# How to test the PR

Install dependencies - npm install
Run tests - npm run test
Run local deplyoment - npm run start:proxy

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Update the JavaScript client library to the latest version and adapt API usage accordingly

Enhancements:
- Refactor useConfigApi hook to use ConfigManagerClient factory instead of DefaultApi

Build:
- Bump @redhat-cloud-services/config-manager-client dependency to v4.0.1.