### PR TITLE
feat(RHINENG-20953): Lightspeed rebrand

### DIFF
--- a/src/Components/AboutRemoteHostConfigPopover/AboutRemoteHostConfigPopover.js
+++ b/src/Components/AboutRemoteHostConfigPopover/AboutRemoteHostConfigPopover.js
@@ -11,8 +11,13 @@ import {
 } from '@patternfly/react-icons';
 
 import { RegisterWithActivationKey } from '../FormGroups';
+import useFeatureFlag from '../../hooks/useFeatureFlag';
 
 const ConnectSystemsModal = () => {
+  const isLightspeedRebrandEnabled = useFeatureFlag(
+    'platform.lightspeed-rebrand'
+  );
+
   return (
     <Popover
       headerContent="About Remote Host Configuration Manager"
@@ -22,16 +27,24 @@ const ConnectSystemsModal = () => {
         <Content className="pf-v6-u-font-size-sm">
           <Content component="p">
             Remote host configuration (rhc) allows you to register with Red Hat
-            Subscription Management (RHSM), connect to Red Hat Insights, and
-            manage your Insights connections with one command.
+            Subscription Management (RHSM), connect to Red Hat{' '}
+            {isLightspeedRebrandEnabled ? 'Lightspeed' : 'Insights'}, and manage
+            your{' '}
+            {isLightspeedRebrandEnabled ? 'Red Hat Lightspeed' : 'Insights'}{' '}
+            connections with one command.
             <br /> rhc can enable Cloud Connector on supported configurations to
-            allow for remediation of Insights issues directly from
-            console.redhat.com.
+            allow for remediation of{' '}
+            {isLightspeedRebrandEnabled
+              ? 'Red Hat Lightspeed'
+              : 'Insights'}{' '}
+            issues directly from console.redhat.com.
             <br />
           </Content>
           <Content component="p">
             Remote host configuration connects RHEL 7.9+ and 8.4+ systems. To
-            register other systems with RHSM or Insights, check out the{' '}
+            register other systems with RHSM or{' '}
+            {isLightspeedRebrandEnabled ? 'Red Hat Lightspeed' : 'Insights'},
+            check out the{' '}
             <Content
               href="./insights/registration"
               component="a"

--- a/src/Components/Services/Services.js
+++ b/src/Components/Services/Services.js
@@ -18,6 +18,8 @@ import { usePermissions } from '@redhat-cloud-services/frontend-components-utili
 import { permissions } from './permissionsConfig';
 import ConditionalTooltip from '../shared/ConditionalTooltip';
 
+import useFeatureFlag from '../../hooks/useFeatureFlag';
+
 const Services = ({
   defaults = { compliance: false, active: false, remediations: false },
   setConfirmChangesOpen,
@@ -34,6 +36,10 @@ const Services = ({
     ],
     false,
     true
+  );
+
+  const isLightspeedRebrandEnabled = useFeatureFlag(
+    'platform.lightspeed-rebrand'
   );
 
   const NO_ACCESS_TOOLTIP_CONTENT = (
@@ -63,7 +69,9 @@ const Services = ({
           </Thead>
           <Tbody>
             {permissions.map((row) => (
-              <Tr key={row.name}>
+              <Tr
+                key={isLightspeedRebrandEnabled ? row.nameLigthspeed : row.name}
+              >
                 <Td
                   dataLabel="Permission"
                   width={80}
@@ -73,7 +81,11 @@ const Services = ({
                     <StackItem>
                       <Flex>
                         <FlexItem>
-                          <b>{row.name}</b>
+                          <b>
+                            {isLightspeedRebrandEnabled
+                              ? row.nameLigthspeed
+                              : row.name}
+                          </b>
                         </FlexItem>
                         {row.additionalInfo && (
                           <FlexItem

--- a/src/Components/Services/permissionsConfig.js
+++ b/src/Components/Services/permissionsConfig.js
@@ -2,6 +2,8 @@ export const permissions = [
   {
     id: 'remediations',
     name: 'Allow permitted Insights users to execute remediation playbooks on rhc-connected systems',
+    nameLigthspeed:
+      'Allow permitted Red Hat Lightspeed users to execute remediation playbooks on rhc-connected systems',
     description:
       'Users with Remediations administrator access can execute Ansible Playbooks on rhc-connected systems in inventory.\nNOTE: This setting does not enable remote playbook remediations on Satellite-managed content hosts. ',
     links: [


### PR DESCRIPTION
# Description

Associated Jira ticket: # [RHINENG-20953
](https://issues.redhat.com/browse/RHINENG-20953)
Rebrand of RHC Manager from Insights to Red Hat Lightspeed.


# How to test the PR

Visit RHC Manager page and check all "Insights" occurances are changed to "Red Hat Lightspeed".