### PR TITLE
feat(RHINENG-18278): Update rbac permissions checks

### DIFF
--- a/src/Components/Authentication/Authentication.js
+++ b/src/Components/Authentication/Authentication.js
@@ -13,10 +13,8 @@ const Authentication = ({ children }) => {
   const location = useLocation();
   const chrome = useChrome();
   const { isLoading, isFetching, isSuccess, isError, data } = useUser();
-  const hasAnyPermission =
-    data?.rbacPermissions &&
-    (data.rbacPermissions.canReadActivationKeys ||
-      data.rbacPermissions.canWriteActivationKeys);
+  const hasPermissions =
+    data?.rbacPermissions && data.rbacPermissions.canReadConfigManagerProfile;
 
   useEffect(() => {
     isSuccess && chrome?.hideGlobalFilter();
@@ -34,7 +32,7 @@ const Authentication = ({ children }) => {
     return <Unavailable />;
   } else if (isLoading === true || isFetching === true) {
     return <Loading />;
-  } else if (isSuccess === true && !hasAnyPermission) {
+  } else if (isSuccess === true && !hasPermissions) {
     return <NotAuthorized serviceName="Remote Host Configuration" />;
   } else if (isSuccess === true) {
     return <>{children}</>;

--- a/src/Components/Authentication/__tests__/Authentication.test.js
+++ b/src/Components/Authentication/__tests__/Authentication.test.js
@@ -60,7 +60,10 @@ describe('Authentication', () => {
 
   describe('with all permissions', () => {
     def('rbacPermissions', () => {
-      return { canReadActivationKeys: false, canWriteActivationKeys: true };
+      return {
+        canReadConfigManagerProfile: false,
+        canWriteConfigManagerProfile: true,
+      };
     });
 
     it('renders correctly with all permissions', async () => {
@@ -72,7 +75,10 @@ describe('Authentication', () => {
 
   describe('when user has some permissions', () => {
     def('rbacPermissions', () => {
-      return { canReadActivationKeys: false, canWriteActivationKeys: true };
+      return {
+        canReadConfigManagerProfile: false,
+        canWriteConfigManagerProfile: true,
+      };
     });
 
     it('renders content correctly', async () => {
@@ -84,7 +90,10 @@ describe('Authentication', () => {
 
   describe('when user has no permissions', () => {
     def('rbacPermissions', () => {
-      return { canReadActivationKeys: false, canWriteActivationKeys: false };
+      return {
+        canReadConfigManagerProfile: false,
+        canWriteConfigManagerProfile: false,
+      };
     });
 
     it('renders the NotAuthorized', async () => {

--- a/src/Components/Authentication/__tests__/__snapshots__/Authentication.test.js.snap
+++ b/src/Components/Authentication/__tests__/__snapshots__/Authentication.test.js.snap
@@ -79,12 +79,154 @@ exports[`Authentication when user has no permissions renders the NotAuthorized 1
 
 exports[`Authentication when user has some permissions renders content correctly 1`] = `
 <div>
-  Authentication Test Content
+  <div
+    class="pf-v6-c-empty-state"
+    data-ouia-component-id="UnauthorizedAccess"
+  >
+    <div
+      class="pf-v6-c-empty-state__content"
+    >
+      <div
+        class="pf-v6-c-empty-state__header"
+      >
+        <div
+          class="pf-v6-c-empty-state__icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="pf-v6-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+            />
+          </svg>
+        </div>
+        <div
+          class="pf-v6-c-empty-state__title"
+        >
+          <h5
+            class="pf-v6-c-empty-state__title-text"
+          >
+            You do not have access to Remote Host Configuration
+          </h5>
+        </div>
+      </div>
+      <div
+        class="pf-v6-c-empty-state__body"
+        data-ouia-component-id="UnauthorizedAccess-body"
+      >
+        Contact your organization administrator(s) for more information or visit 
+        <a
+          href="./iam/my-user-access"
+        >
+          My User Access
+        </a>
+         to learn more about your permissions.
+      </div>
+      <div
+        class="pf-v6-c-empty-state__footer"
+        data-ouia-component-id="UnauthorizedAccess-footer"
+      >
+        <a
+          class="pf-v6-c-button pf-m-primary"
+          data-ouia-component-id="UnauthorizedAccess-home-button"
+          data-ouia-component-type="PF6/Button"
+          data-ouia-safe="true"
+          href="."
+        >
+          <span
+            class="pf-v6-c-button__text"
+          >
+            Go to landing page
+          </span>
+        </a>
+        <div
+          class="pf-v6-c-empty-state__actions"
+        />
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Authentication with all permissions renders correctly with all permissions 1`] = `
 <div>
-  Authentication Test Content
+  <div
+    class="pf-v6-c-empty-state"
+    data-ouia-component-id="UnauthorizedAccess"
+  >
+    <div
+      class="pf-v6-c-empty-state__content"
+    >
+      <div
+        class="pf-v6-c-empty-state__header"
+      >
+        <div
+          class="pf-v6-c-empty-state__icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="pf-v6-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+            />
+          </svg>
+        </div>
+        <div
+          class="pf-v6-c-empty-state__title"
+        >
+          <h5
+            class="pf-v6-c-empty-state__title-text"
+          >
+            You do not have access to Remote Host Configuration
+          </h5>
+        </div>
+      </div>
+      <div
+        class="pf-v6-c-empty-state__body"
+        data-ouia-component-id="UnauthorizedAccess-body"
+      >
+        Contact your organization administrator(s) for more information or visit 
+        <a
+          href="./iam/my-user-access"
+        >
+          My User Access
+        </a>
+         to learn more about your permissions.
+      </div>
+      <div
+        class="pf-v6-c-empty-state__footer"
+        data-ouia-component-id="UnauthorizedAccess-footer"
+      >
+        <a
+          class="pf-v6-c-button pf-m-primary"
+          data-ouia-component-id="UnauthorizedAccess-home-button"
+          data-ouia-component-type="PF6/Button"
+          data-ouia-safe="true"
+          href="."
+        >
+          <span
+            class="pf-v6-c-button__text"
+          >
+            Go to landing page
+          </span>
+        </a>
+        <div
+          class="pf-v6-c-empty-state__actions"
+        />
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/src/Components/Services/Services.js
+++ b/src/Components/Services/Services.js
@@ -13,12 +13,12 @@ import {
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import propTypes from 'prop-types';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
-import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 
 import { permissions } from './permissionsConfig';
 import ConditionalTooltip from '../shared/ConditionalTooltip';
 
 import useFeatureFlag from '../../hooks/useFeatureFlag';
+import { useRbacPermissions } from '../../hooks/useRbacPermissions';
 
 const Services = ({
   defaults = { compliance: false, active: false, remediations: false },
@@ -26,16 +26,13 @@ const Services = ({
   onChange,
   isLoading,
 }) => {
-  const { hasAccess, isLoading: isRbacLoading } = usePermissions(
-    '',
-    [
-      'config-manager:activation_keys:*',
-      'inventory:hosts:read',
-      'inventory:hosts:write',
-      'playbook-dispatcher:run:read',
-    ],
-    false,
-    true
+  const { data: rbacPermissions, isLoading: isRbacLoading } =
+    useRbacPermissions();
+  const hasAccess = Boolean(
+    rbacPermissions?.canReadConfigManagerProfile &&
+      rbacPermissions?.canWriteConfigManagerProfile &&
+      rbacPermissions?.canReadInventoryHosts &&
+      rbacPermissions?.canWriteInventoryHosts
   );
 
   const isLightspeedRebrandEnabled = useFeatureFlag(

--- a/src/Routes/Dashboard/index.js
+++ b/src/Routes/Dashboard/index.js
@@ -67,7 +67,7 @@ const SamplePage = () => {
       connectedSystemsReducer,
     });
     dispatch(fetchCurrState());
-    if (userData.rbacPermissions.canReadInventory) {
+    if (userData.rbacPermissions.canReadInventoryHosts) {
       dispatch(fetchConnectedHosts());
     }
   }, [getRegistry, userData]);

--- a/src/hooks/__tests__/useRbacPermissions.test.js
+++ b/src/hooks/__tests__/useRbacPermissions.test.js
@@ -9,15 +9,19 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
       Promise.resolve([
         {
           resourceDefinitions: [],
-          permission: 'config-manager:activation_keys:*',
+          permission: 'config-manager:profile:read',
         },
         {
           resourceDefinitions: [],
-          permission: 'config-manager:activation_keys:read',
+          permission: 'config-manager:profile:write',
         },
         {
           resourceDefinitions: [],
           permission: 'inventory:hosts:read',
+        },
+        {
+          resourceDefinitions: [],
+          permission: 'inventory:hosts:write',
         },
       ]),
   }),
@@ -25,9 +29,10 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 describe('useRbacPermissions', () => {
   let rbacObject = {
-    canReadActivationKeys: true,
-    canWriteActivationKeys: true,
-    canReadInventory: true,
+    canReadConfigManagerProfile: true,
+    canWriteConfigManagerProfile: true,
+    canReadInventoryHosts: true,
+    canWriteInventoryHosts: true,
   };
 
   it('build and returns rbac permissions object from the API', async () => {

--- a/src/hooks/__tests__/useUser.test.js
+++ b/src/hooks/__tests__/useUser.test.js
@@ -9,15 +9,19 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
       Promise.resolve([
         {
           resourceDefinitions: [],
-          permission: 'config-manager:activation_keys:*',
+          permission: 'config-manager:profile:read',
         },
         {
           resourceDefinitions: [],
-          permission: 'config-manager:activation_keys:read',
+          permission: 'config-manager:profile:write',
         },
         {
           resourceDefinitions: [],
           permission: 'inventory:hosts:read',
+        },
+        {
+          resourceDefinitions: [],
+          permission: 'inventory:hosts:write',
         },
       ]),
     auth: {
@@ -50,9 +54,10 @@ describe('useUser hook', () => {
       accountNumber: '1',
       orgId: 1,
       rbacPermissions: {
-        canReadActivationKeys: true,
-        canWriteActivationKeys: true,
-        canReadInventory: true,
+        canReadConfigManagerProfile: true,
+        canWriteConfigManagerProfile: true,
+        canReadInventoryHosts: true,
+        canWriteInventoryHosts: true,
       },
     });
   });

--- a/src/hooks/useRbacPermissions.js
+++ b/src/hooks/useRbacPermissions.js
@@ -9,14 +9,17 @@ const getUserRbacPermissions = (permissions) => {
       .map((rawPermission) => rawPermission.permission);
 
     const rbacPermissions = {
-      canReadActivationKeys: doesHavePermissions(permissions, [
-        'config-manager:activation_keys:read',
+      canReadConfigManagerProfile: doesHavePermissions(permissions, [
+        'config-manager:profile:read',
       ]),
-      canWriteActivationKeys: doesHavePermissions(permissions, [
-        'config-manager:activation_keys:write',
+      canWriteConfigManagerProfile: doesHavePermissions(permissions, [
+        'config-manager:profile:write',
       ]),
-      canReadInventory: doesHavePermissions(permissions, [
+      canReadInventoryHosts: doesHavePermissions(permissions, [
         'inventory:hosts:read',
+      ]),
+      canWriteInventoryHosts: doesHavePermissions(permissions, [
+        'inventory:hosts:write',
       ]),
     };
 


### PR DESCRIPTION
# Description

Associated Jira ticket: RHINENG-18278

The app previously derived a user’s access from the **config-manager:activation-keys** RBAC permissions, but that approach is no longer valid. Two new RBAC permissions - **config-manager:profile:read** and **config-manager:profile:write** - have been introduced and should now be treated as the source of truth for user access in the RHC UI. In addition, the previous check againts the **playbook-dispatcher** RBAC permission is also obsolete.

**Updated permission rules:**

- Users without config-manager:profile:read must be shown the “You have no access…” page

- Users without any of the required permissions (config-manager:profile:read, config-manager:profile:write, inventory:hosts:read, inventory:hosts:write) must not be able to toggle Enabled/Disabled on the /insights/connector page

# How to test the PR

- Ensure that user without **config-manager:profile:read** RBAC permission cannot access the _/insights/connector_ page

- Ensure that user without any of the following RBAC permissions cannot change RHC Permissions settings ("Enabled/Disabled" switch) on _/insights/connector_ page:
-- config-manager:profile:read
-- config-manager:profile:write
-- inventory:hosts:read
-- inventory:hosts:write

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
